### PR TITLE
clarify install instructions + make readme less of an instant redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# This repository is a friendly fork of https://github.com/wercker/stern - discontinued due to lack of maintainers.
-
 # stern
+
+fork of discontinued [wercker/stern](https://github.com/wercker/stern)
 
 Stern allows you to `tail` multiple pods on Kubernetes and multiple containers
 within the pod. Each result is color coded for quicker debugging.
@@ -16,7 +16,11 @@ limit what containers to show. By default all containers are listened to.
 
 ## Installation
 
-If you don't want to build from source go grab a [binary release](https://github.com/stern/stern/releases)
+### Option A: download binary
+
+Download a [binary release](https://github.com/stern/stern/releases)
+
+### Options B: build from source
 
 [Govendor](https://github.com/kardianos/govendor) is required to install vendored dependencies.
 


### PR DESCRIPTION
if you want to find more users, maybe don't send them away ;)

<img width="1120" alt="Screen Shot 2020-10-23 at 9 17 04 AM" src="https://user-images.githubusercontent.com/11367/97028110-85009500-1510-11eb-9a92-fbbdf71d4645.png">
vs
<img width="1455" alt="Screen Shot 2020-10-23 at 9 17 18 AM" src="https://user-images.githubusercontent.com/11367/97028135-8e89fd00-1510-11eb-8603-2b9e512371ea.png">
