### PR TITLE
No longer need govendor to build from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ Download a [binary release](https://github.com/stern/stern/releases)
 
 ### Options B: build from source
 
-[Govendor](https://github.com/kardianos/govendor) is required to install vendored dependencies.
-
 ```
 git clone https://github.com/stern/stern.git && cd stern
 make install


### PR DESCRIPTION
Ref #61 