### PR TITLE
Change the installation method by "build from source" to go get

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,6 @@ GO ?= GO111MODULE=on GOPROXY=https://gocenter.io go
 build:
 	$(GO) build -o dist/stern .
 
-.PHONY: install
-install:
-	$(GO) install .
-
 TOOLS_DIR := hack/tools
 TOOLS_BIN_DIR := $(TOOLS_DIR)/bin
 GORELEASER_BIN := bin/goreleaser

--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ Download a [binary release](https://github.com/stern/stern/releases)
 ### Options B: build from source
 
 ```
-git clone https://github.com/stern/stern.git && cd stern
-make install
+go get -u github.com/stern/stern
 ```
 
 ## Usage


### PR DESCRIPTION
We have already changed to use go modules so we can install with `go get`.

I tested it in the following way:
```
$ docker run --rm golang:1.15 sh -c "go get -u github.com/stern/stern && bin/stern --version"
Unable to find image 'golang:1.15' locally
1.15: Pulling from library/golang
Digest: sha256:1ba0da74b20aad52b091877b0e0ece503c563f39e37aa6b0e46777c4d820a2ae
Status: Downloaded newer image for golang:1.15
stern version 1.11.0
```

Closes https://github.com/stern/stern/issues/55