### PR TITLE
Provide container images

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,12 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: stern-robot
+        password: ${{ secrets.CR_PAT }}
     - name: Release
       run: make release
       env:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,3 +30,9 @@ checksum:
   name_template: 'checksums.txt'
 changelog:
   sort: asc
+dockers:
+- image_templates:
+  - "ghcr.io/stern/stern:latest"
+  - "ghcr.io/stern/stern:{{ .Major }}"
+  - "ghcr.io/stern/stern:{{ .Major }}.{{ .Minor }}"
+  - "ghcr.io/stern/stern:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM gcr.io/distroless/static-debian10
+COPY stern /usr/local/bin/
+ENTRYPOINT ["/usr/local/bin/stern"]

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ $(GORELEASER): $(TOOLS_DIR)/go.mod
 build-cross: $(GORELEASER)
 	$(GORELEASER) build --snapshot --rm-dist
 
-.PHONY: archive
-archive: $(GORELEASER)
+.PHONY: dist
+dist: $(GORELEASER)
 	$(GORELEASER) release --rm-dist --skip-publish --snapshot
 
 .PHONY: release

--- a/README.md
+++ b/README.md
@@ -188,6 +188,22 @@ If you use zsh, just source the stern zsh completion code in `.zshrc`.
 source <(stern --completion=zsh)
 ```
 
+## Running with container
+
+You can also use stern using a container:
+
+```
+docker run ghcr.io/stern/stern --version
+```
+
+If you are using a minikube cluster, you need to run a container as follows:
+
+```
+docker run --rm -v "$HOME/.minikube:$HOME/.minikube" -v "$HOME/.kube:/$HOME/.kube" -e KUBECONFIG="$HOME/.kube/config" ghcr.io/stern/stern .
+```
+
+You can find container image tags in https://github.com/orgs/stern/packages?repo_name=stern.
+
 ## Contributing to this repository
 
 Please see [CONTRIBUTING](CONTRIBUTING.md) for details.


### PR DESCRIPTION
We provide container images for stern. The container registry is GitHub Container Registry. The image can be built with the following command (using goreleaser):

```
make dist
```

Image tags will be created according to the following rules:

- `ghcr.io/stern/stern:latest`
- `ghcr.io/stern/stern:{{ .Major }}`
- `ghcr.io/stern/stern:{{ .Major }}.{{ .Minor }}`
- `ghcr.io/stern/stern:{{ .Major }}.{{ .Minor }}.{{ .Patch }}`

This PR updates the release workflow to automatically upload container images on release. The personal access token (`CR_PAT`) for uploading images is from the [stern-robot](https://github.com/stern-robot) account who is created by me.

Closes https://github.com/stern/stern/issues/33, https://github.com/stern/stern/issues/34