### PR TITLE
Use --skip-validate with goreleaser release at release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,10 @@ GOLANGCI_LINT_BIN := bin/golangci-lint
 GOLANGCI_LINT := $(TOOLS_DIR)/$(GOLANGCI_LINT_BIN)
 
 $(GORELEASER): $(TOOLS_DIR)/go.mod
-	cd $(TOOLS_DIR) && go build -o $(GORELEASER_BIN) github.com/goreleaser/goreleaser
+	cd $(TOOLS_DIR) && $(GO) build -o $(GORELEASER_BIN) github.com/goreleaser/goreleaser
 
 $(GOLANGCI_LINT): $(TOOLS_DIR)/go.mod
-	cd $(TOOLS_DIR) && go build -o $(GOLANGCI_LINT_BIN) github.com/golangci/golangci-lint/cmd/golangci-lint
+	cd $(TOOLS_DIR) && $(GO) build -o $(GOLANGCI_LINT_BIN) github.com/golangci/golangci-lint/cmd/golangci-lint
 
 .PHONY: build-cross
 build-cross: $(GORELEASER)
@@ -25,7 +25,7 @@ build-cross: $(GORELEASER)
 
 .PHONY: test
 test:
-	go test -v ./...
+	$(GO) test -v ./...
 
 .PHONY: lint
 lint: $(GOLANGCI_LINT)
@@ -37,7 +37,7 @@ dist: $(GORELEASER)
 
 .PHONY: release
 release: $(GORELEASER)
-	$(GORELEASER) release --rm-dist
+	$(GORELEASER) release --rm-dist --skip-validate
 
 .PHONY: clean
 clean: clean-tools clean-dist


### PR DESCRIPTION
This is to avoid the "git is currently in a dirty state" error for hack/tools/go.sum file.

- https://github.com/stern/stern/runs/1308798250?check_suite_focus=true#step:6:84

I didn't know how to get around this error. Tools are only used to build stern and do not affect the release.