### PR TITLE
Use ldflags to set version information

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,9 +7,9 @@ builds:
   ldflags:
   - -s
   - -w
-  - -X github.com/stern/stern.Version={{.Version}}
-  - -X github.com/stern/stern.GitCommit={{.Commit}}
-  - -X github.com/stern/stern.Date={{.Date}}
+  - -X github.com/stern/stern/cmd.version={{.Version}}
+  - -X github.com/stern/stern/cmd.commit={{.Commit}}
+  - -X github.com/stern/stern/cmd.date={{.Date}}
   goos:
   - linux
   - windows

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -35,7 +35,11 @@ import (
 	"github.com/fatih/color"
 )
 
-const version = "1.12.1"
+var (
+	version = "dev"
+	commit  = ""
+	date    = ""
+)
 
 type Options struct {
 	container        string
@@ -109,7 +113,7 @@ func Run() {
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		if opts.version {
-			fmt.Printf("stern version %s\n", version)
+			fmt.Println(buildVersion(version, commit, date))
 			return nil
 		}
 
@@ -307,4 +311,18 @@ func getKubeConfig() (string, error) {
 	kubeconfig = filepath.Join(home, ".kube/config")
 
 	return kubeconfig, nil
+}
+
+func buildVersion(version, commit, date string) string {
+	result := fmt.Sprintf("version: %s", version)
+
+	if commit != "" {
+		result = fmt.Sprintf("%s\ncommit: %s", result, commit)
+	}
+
+	if date != "" {
+		result = fmt.Sprintf("%s\nbuilt at: %s", result, date)
+	}
+
+	return result
 }


### PR DESCRIPTION
Version information is output in the following format:
```
$ stern --version
version: v1.12.1
commit: 2d4bd0de2d950b189eba7a7ebf8120283b7009c0
built at: 2020-10-27T14:13:08Z
```