### PR TITLE
Run `go fmt` and `go vet` against code

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,9 +24,7 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-    - name: Run test
+    - name: Run tests
       run: make test
-    - name: Run lint
-      run: make lint
     - name: Build binary
       run: make build

--- a/Makefile
+++ b/Makefile
@@ -24,12 +24,20 @@ build-cross: $(GORELEASER)
 	$(GORELEASER) build --snapshot --rm-dist
 
 .PHONY: test
-test:
+test: fmt vet lint
 	$(GO) test -v ./...
 
 .PHONY: lint
 lint: $(GOLANGCI_LINT)
 	$(GOLANGCI_LINT) run
+
+.PHONY: fmt
+fmt:
+	go fmt ./...
+
+.PHONY: vet
+vet:
+	go vet ./...
 
 .PHONY: dist
 dist: $(GORELEASER)

--- a/stern/tail.go
+++ b/stern/tail.go
@@ -138,7 +138,7 @@ func (t *Tail) Start(ctx context.Context, i v1.PodInterface) {
 						break
 					}
 				}
- 				if !matches {
+				if !matches {
 					continue OUTER
 				}
 			}


### PR DESCRIPTION
It keeps code to be easier to write, read, and maintain.