### PR TITLE
Remove a line break from .Message in the --template option

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,13 +149,13 @@ stern backend -o raw
 Output using a custom template:
 
 ```
-stern --template '{{.Message}} ({{.Namespace}}/{{.PodName}}/{{.ContainerName}})' backend
+stern --template '{{printf "%s (%s/%s/%s)\n" .Message .Namespace .PodName .ContainerName}}' backend
 ```
 
 Output using a custom template with stern-provided colors:
 
 ```
-stern --template '{{.Message}} ({{.Namespace}}/{{color .PodColor .PodName}}/{{color .ContainerColor .ContainerName}})' backend
+stern --template '{{.Message}} ({{.Namespace}}/{{color .PodColor .PodName}}/{{color .ContainerColor .ContainerName}}){{"\n"}}' backend
 ```
 
 ## Completion

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -250,8 +250,9 @@ func parseConfig(args []string) (*stern.Config, error) {
 		case "raw":
 			t = "{{.Message}}"
 		case "json":
-			t = "{{json .}}\n"
+			t = "{{json .}}"
 		}
+		t += "\n"
 	}
 
 	funs := map[string]interface{}{

--- a/stern/tail_test.go
+++ b/stern/tail_test.go
@@ -1,6 +1,13 @@
 package stern
 
-import "testing"
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"regexp"
+	"testing"
+	"text/template"
+)
 
 func TestDetermineColor(t *testing.T) {
 	podName := "stern"
@@ -14,5 +21,72 @@ func TestDetermineColor(t *testing.T) {
 	if containerColor1 != containerColor2 {
 		t.Errorf("expected color for container to be the same between invocations but was %v and %v",
 			containerColor1, containerColor2)
+	}
+}
+
+func TestIsIncludeTestOptions(t *testing.T) {
+	msg := "this is a log message"
+
+	tests := []struct {
+		include  []*regexp.Regexp
+		expected bool
+	}{
+		{
+			include:  []*regexp.Regexp{},
+			expected: true,
+		},
+		{
+			include: []*regexp.Regexp{
+				regexp.MustCompile(`this is not`),
+			},
+			expected: false,
+		},
+		{
+			include: []*regexp.Regexp{
+				regexp.MustCompile(`this is`),
+			},
+			expected: true,
+		},
+	}
+
+	for i, tt := range tests {
+		o := &TailOptions{Include: tt.include}
+		if o.IsInclude(msg) != tt.expected {
+			t.Errorf("%d: expected %s, but actual %s", i, fmt.Sprint(tt.expected), fmt.Sprint(!tt.expected))
+		}
+	}
+}
+
+func TestConsumeStreamTail(t *testing.T) {
+	tests := []struct {
+		tmpl     *template.Template
+		stream   io.Reader
+		expected []byte
+	}{
+		{
+			tmpl: template.Must(template.New("").Parse(`{{printf "%s (%s/%s/%s)\n" .Message .Namespace .PodName .ContainerName}}`)),
+			stream: bytes.NewBufferString(`line 1
+line 2
+line 3
+line 4`),
+			expected: []byte(`line 1 (my-namespace/my-pod/my-container)
+line 2 (my-namespace/my-pod/my-container)
+line 3 (my-namespace/my-pod/my-container)
+line 4 (my-namespace/my-pod/my-container)
+`),
+		},
+	}
+
+	for i, tt := range tests {
+		tail := NewTail("my-namespace", "my-pod", "my-container", tt.tmpl, &TailOptions{})
+		out := new(bytes.Buffer)
+
+		if err := tail.ConsumeStream(tt.stream, out); err != nil {
+			t.Fatalf("%d: unexpected err %v", i, err)
+		}
+
+		if !bytes.Equal(tt.expected, out.Bytes()) {
+			t.Errorf("%d: expected %s, but actual %s", i, tt.expected, out)
+		}
 	}
 }


### PR DESCRIPTION
With this change, a line break is removed from `.Message` in the
`--template` option. This will cause the following `--template` option
to work as expected.

**Before**:
```
$ stern --template '{{.Message}} ({{.Namespace}}/{{.PodName}}/{{.ContainerName}}){{"\n"}}' .
+ nginx-6d755df9b8-jzchs › nginx
/docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
 (default/nginx-6d755df9b8-jzchs/nginx)
/docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
 (default/nginx-6d755df9b8-jzchs/nginx)
/docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
 (default/nginx-6d755df9b8-jzchs/nginx)
10-listen-on-ipv6-by-default.sh: Getting the checksum of /etc/nginx/conf.d/default.conf
 (default/nginx-6d755df9b8-jzchs/nginx)
10-listen-on-ipv6-by-default.sh: Enabled listen on IPv6 in /etc/nginx/conf.d/default.conf
 (default/nginx-6d755df9b8-jzchs/nginx)
/docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
 (default/nginx-6d755df9b8-jzchs/nginx)
/docker-entrypoint.sh: Configuration complete; ready for start up
 (default/nginx-6d755df9b8-jzchs/nginx)
```

**After**:
```
$ stern --template '{{.Message}} ({{.Namespace}}/{{.PodName}}/{{.ContainerName}}){{"\n"}}' .
+ nginx-6d755df9b8-jzchs › nginx
/docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration (default/nginx-6d755df9b8-jzchs/nginx)
/docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/ (default/nginx-6d755df9b8-jzchs/nginx)
/docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh (default/nginx-6d755df9b8-jzchs/nginx)
10-listen-on-ipv6-by-default.sh: Getting the checksum of /etc/nginx/conf.d/default.conf (default/nginx-6d755df9b8-jzchs/nginx)
10-listen-on-ipv6-by-default.sh: Enabled listen on IPv6 in /etc/nginx/conf.d/default.conf (default/nginx-6d755df9b8-jzchs/nginx)
/docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh (default/nginx-6d755df9b8-jzchs/nginx)
/docker-entrypoint.sh: Configuration complete; ready for start up (default/nginx-6d755df9b8-jzchs/nginx)
```

Fixes #88 