### PR TITLE
Add `.NodeName` to template variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,13 @@ It accepts a custom template through the `--template` flag, which will be
 compiled to a Go template and then used for every log message. This Go template
 will receive the following struct:
 
-| property        | type   | description               |
-|-----------------|--------|---------------------------|
-| `Message`       | string | The log message itself    |
-| `Namespace`     | string | The namespace of the pod  |
-| `PodName`       | string | The name of the pod       |
-| `ContainerName` | string | The name of the container |
+| property        | type   | description                                 |
+|-----------------|--------|---------------------------------------------|
+| `Message`       | string | The log message itself                      |
+| `NodeName`      | string | The node name where the pod is scheduled on |
+| `Namespace`     | string | The namespace of the pod                    |
+| `PodName`       | string | The name of the pod                         |
+| `ContainerName` | string | The name of the container                   |
 
 The following functions are available within the template (besides the [builtin
 functions](https://golang.org/pkg/text/template/#hdr-Functions)):
@@ -149,7 +150,7 @@ stern backend -o raw
 Output using a custom template:
 
 ```
-stern --template '{{printf "%s (%s/%s/%s)\n" .Message .Namespace .PodName .ContainerName}}' backend
+stern --template '{{printf "%s (%s/%s/%s/%s)\n" .Message .NodeName .Namespace .PodName .ContainerName}}' backend
 ```
 
 Output using a custom template with stern-provided colors:

--- a/stern/main.go
+++ b/stern/main.go
@@ -64,7 +64,7 @@ func Run(ctx context.Context, config *Config) error {
 				continue
 			}
 
-			tail := NewTail(p.Namespace, p.Pod, p.Container, config.Template, &TailOptions{
+			tail := NewTail(p.Node, p.Namespace, p.Pod, p.Container, config.Template, &TailOptions{
 				Timestamps:   config.Timestamps,
 				SinceSeconds: int64(config.Since.Seconds()),
 				Exclude:      config.Exclude,

--- a/stern/tail.go
+++ b/stern/tail.go
@@ -32,6 +32,7 @@ import (
 )
 
 type Tail struct {
+	NodeName       string
 	Namespace      string
 	PodName        string
 	ContainerName  string
@@ -76,8 +77,9 @@ func (o TailOptions) IsInclude(msg string) bool {
 }
 
 // NewTail returns a new tail for a Kubernetes container inside a pod
-func NewTail(namespace, podName, containerName string, tmpl *template.Template, options *TailOptions) *Tail {
+func NewTail(nodeName, namespace, podName, containerName string, tmpl *template.Template, options *TailOptions) *Tail {
 	return &Tail{
+		NodeName:      nodeName,
 		Namespace:     namespace,
 		PodName:       podName,
 		ContainerName: containerName,
@@ -189,6 +191,7 @@ func (t *Tail) ConsumeStream(stream io.Reader, out io.Writer) error {
 func (t *Tail) Print(msg string, out io.Writer) {
 	vm := Log{
 		Message:        msg,
+		NodeName:       t.NodeName,
 		Namespace:      t.Namespace,
 		PodName:        t.PodName,
 		ContainerName:  t.ContainerName,
@@ -205,6 +208,9 @@ func (t *Tail) Print(msg string, out io.Writer) {
 type Log struct {
 	// Message is the log message itself
 	Message string `json:"message"`
+
+	// Node name of the pod
+	NodeName string `json:"nodeName"`
 
 	// Namespace of the pod
 	Namespace string `json:"namespace"`

--- a/stern/tail_test.go
+++ b/stern/tail_test.go
@@ -64,21 +64,21 @@ func TestConsumeStreamTail(t *testing.T) {
 		expected []byte
 	}{
 		{
-			tmpl: template.Must(template.New("").Parse(`{{printf "%s (%s/%s/%s)\n" .Message .Namespace .PodName .ContainerName}}`)),
+			tmpl: template.Must(template.New("").Parse(`{{printf "%s (%s/%s/%s/%s)\n" .Message .NodeName .Namespace .PodName .ContainerName}}`)),
 			stream: bytes.NewBufferString(`line 1
 line 2
 line 3
 line 4`),
-			expected: []byte(`line 1 (my-namespace/my-pod/my-container)
-line 2 (my-namespace/my-pod/my-container)
-line 3 (my-namespace/my-pod/my-container)
-line 4 (my-namespace/my-pod/my-container)
+			expected: []byte(`line 1 (my-node/my-namespace/my-pod/my-container)
+line 2 (my-node/my-namespace/my-pod/my-container)
+line 3 (my-node/my-namespace/my-pod/my-container)
+line 4 (my-node/my-namespace/my-pod/my-container)
 `),
 		},
 	}
 
 	for i, tt := range tests {
-		tail := NewTail("my-namespace", "my-pod", "my-container", tt.tmpl, &TailOptions{})
+		tail := NewTail("my-node", "my-namespace", "my-pod", "my-container", tt.tmpl, &TailOptions{})
 		out := new(bytes.Buffer)
 
 		if err := tail.ConsumeStream(tt.stream, out); err != nil {

--- a/stern/watch.go
+++ b/stern/watch.go
@@ -25,11 +25,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/kubernetes/typed/core/v1"
+	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
 // Target is a target to watch
 type Target struct {
+	Node      string
 	Namespace string
 	Pod       string
 	Container string
@@ -85,6 +86,7 @@ func Watch(ctx context.Context, i v1.PodInterface, podFilter *regexp.Regexp, con
 
 						if containerState.Match(c.State) {
 							added <- &Target{
+								Node:      pod.Spec.NodeName,
 								Namespace: pod.Namespace,
 								Pod:       pod.Name,
 								Container: c.Name,
@@ -107,6 +109,7 @@ func Watch(ctx context.Context, i v1.PodInterface, podFilter *regexp.Regexp, con
 						}
 
 						removed <- &Target{
+							Node:      pod.Spec.NodeName,
 							Namespace: pod.Namespace,
 							Pod:       pod.Name,
 							Container: c.Name,


### PR DESCRIPTION
This change allows the node name where the pod is scheduled on,
`.NodeName`, to be used as a template variable.

```
stern --template '{{.Message}} ({{.NodeName}}/{{.Namespace}}/{{.PodName}}/{{.ContainerName}}){{"\n"}}' .
```

This PR is based on #91.

Closes #54