### PR TITLE
Support In-Cluster config

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -20,14 +20,12 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
 	"regexp"
 	"text/template"
 	"time"
 
 	"k8s.io/apimachinery/pkg/labels"
 
-	homedir "github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/stern/stern/stern"
@@ -152,11 +150,6 @@ func Run() {
 }
 
 func parseConfig(args []string) (*stern.Config, error) {
-	kubeConfig, err := getKubeConfig()
-	if err != nil {
-		return nil, err
-	}
-
 	var podQuery string
 	if len(args) == 0 {
 		podQuery = ".*"
@@ -277,7 +270,7 @@ func parseConfig(args []string) (*stern.Config, error) {
 	}
 
 	return &stern.Config{
-		KubeConfig:            kubeConfig,
+		KubeConfig:            opts.kubeConfig,
 		PodQuery:              pod,
 		ContainerQuery:        container,
 		ExcludeContainerQuery: excludeContainer,
@@ -293,28 +286,6 @@ func parseConfig(args []string) (*stern.Config, error) {
 		TailLines:             tailLines,
 		Template:              template,
 	}, nil
-}
-
-func getKubeConfig() (string, error) {
-	var kubeconfig string
-
-	if kubeconfig = opts.kubeConfig; kubeconfig != "" {
-		return kubeconfig, nil
-	}
-
-	if kubeconfig = os.Getenv("KUBECONFIG"); kubeconfig != "" {
-		return kubeconfig, nil
-	}
-
-	// kubernetes requires an absolute path
-	home, err := homedir.Dir()
-	if err != nil {
-		return "", errors.Wrap(err, "failed to get user home directory")
-	}
-
-	kubeconfig = filepath.Join(home, ".kube/config")
-
-	return kubeconfig, nil
 }
 
 func buildVersion(version, commit, date string) string {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.15
 
 require (
 	github.com/fatih/color v1.9.0
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.1.1
 	k8s.io/api v0.18.10

--- a/kubernetes/clientset.go
+++ b/kubernetes/clientset.go
@@ -27,13 +27,17 @@ import (
 
 // NewClientConfig returns a new Kubernetes client config set for a context
 func NewClientConfig(configPath string, contextName string) clientcmd.ClientConfig {
-	configPathList := filepath.SplitList(configPath)
-	configLoadingRules := &clientcmd.ClientConfigLoadingRules{}
-	if len(configPathList) <= 1 {
-		configLoadingRules.ExplicitPath = configPath
-	} else {
-		configLoadingRules.Precedence = configPathList
+	configLoadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+
+	if configPath != "" {
+		configPathList := filepath.SplitList(configPath)
+		if len(configPathList) <= 1 {
+			configLoadingRules.ExplicitPath = configPath
+		} else {
+			configLoadingRules.Precedence = configPathList
+		}
 	}
+
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		configLoadingRules,
 		&clientcmd.ConfigOverrides{


### PR DESCRIPTION
fixes #9 

This PR changes to use [`clientcmd.NewDefaultClientConfigLoadingRules`](https://github.com/kubernetes/client-go/blob/master/tools/clientcmd/loader.go#L139-L161) to handle kubeconfig in common way.

This enables resolve kubeconfig in the best practice manner, which resolves in the order of cli options, envvar, `~/.kube/config`, and fallback in-cluster config finally.
