### PR TITLE
README: Recommend `brew install stern` from homebrew-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ asdf install stern latest
 
 If you use [Homebrew](https://brew.sh), you can install like this:
 ```
-brew install stern/stern/stern
+brew install stern
 ```
 
 ## Usage


### PR DESCRIPTION
- As of https://github.com/Homebrew/homebrew-core/commit/7d44ae9f44d112cde586258a28b8bbed22b43f2a, this fork of `stern`, with its latest version, ships in Homebrew's core tap (on macOS and shortly on Linux).
