### PR TITLE
Follow logs of new containers on restarting

### DIFF
--- a/stern/main.go
+++ b/stern/main.go
@@ -61,7 +61,12 @@ func Run(ctx context.Context, config *Config) error {
 		for p := range added {
 			id := p.GetID()
 			if tails[id] != nil {
-				continue
+				if tails[id].isActive() {
+					continue
+				} else {
+					tails[id].Close()
+					delete(tails, id)
+				}
 			}
 
 			tail := NewTail(p.Node, p.Namespace, p.Pod, p.Container, config.Template, &TailOptions{

--- a/stern/watch.go
+++ b/stern/watch.go
@@ -83,14 +83,17 @@ func Watch(ctx context.Context, i v1.PodInterface, podFilter *regexp.Regexp, con
 						if containerExcludeFilter != nil && containerExcludeFilter.MatchString(c.Name) {
 							continue
 						}
+						t := &Target{
+							Node:      pod.Spec.NodeName,
+							Namespace: pod.Namespace,
+							Pod:       pod.Name,
+							Container: c.Name,
+						}
 
 						if containerState.Match(c.State) {
-							added <- &Target{
-								Node:      pod.Spec.NodeName,
-								Namespace: pod.Namespace,
-								Pod:       pod.Name,
-								Container: c.Name,
-							}
+							added <- t
+						} else {
+							removed <- t
 						}
 					}
 				case watch.Deleted:


### PR DESCRIPTION
With this change, stern continues to follows logs of new containers on restarting.

Fixes #6, #7, #13 

You can check that issues are fixed with the following steps:

## Case 1

**Preparing**
```sh
cat <<'EOL' | kubectl apply -f-
apiVersion: v1
kind: Pod
metadata:
  name: foo
spec:
  containers:
    - name: foo
      image: busybox
      command: ["sh", "-c", "touch /log; tail -f /log"]
      readinessProbe:
        initialDelaySeconds: 5
        timeoutSeconds: 5
        exec:
          command: ["sh", "-c", "echo $(date) ::: Readiness probe >> /log; grep imready /foo"]
      livenessProbe:
        initialDelaySeconds: 5
        timeoutSeconds: 5
        exec:
          command: ["sh", "-c", "echo $(date) ::: Liveness probe >> /log; grep imalive /foo"]
EOL
```

**Before**
```sh
$ stern --version
version: 1.13.0
commit: 48835a04b83be525ee1125d308b025dabd741190
built at: 2020-11-06T07:46:45Z
$ stern foo
+ foo › foo
foo foo Sat Nov 21 03:53:31 UTC 2020 ::: Readiness probe
foo foo Sat Nov 21 03:53:31 UTC 2020 ::: Liveness probe
foo foo Sat Nov 21 03:53:41 UTC 2020 ::: Readiness probe
foo foo Sat Nov 21 03:53:41 UTC 2020 ::: Liveness probe
foo foo Sat Nov 21 03:53:51 UTC 2020 ::: Readiness probe
foo foo Sat Nov 21 03:53:51 UTC 2020 ::: Liveness probe
foo foo Sat Nov 21 03:54:01 UTC 2020 ::: Readiness probe
foo foo Sat Nov 21 03:54:11 UTC 2020 ::: Readiness probe
foo foo
# <---- Do not follow logs of the restarted container
```

**After**
```sh
$ dist/stern foo
+ foo › foo
foo foo Sat Nov 21 03:52:31 UTC 2020 ::: Readiness probe
foo foo Sat Nov 21 03:52:31 UTC 2020 ::: Liveness probe
foo foo Sat Nov 21 03:52:41 UTC 2020 ::: Readiness probe
foo foo Sat Nov 21 03:52:41 UTC 2020 ::: Liveness probe
foo foo Sat Nov 21 03:52:51 UTC 2020 ::: Readiness probe
foo foo Sat Nov 21 03:52:51 UTC 2020 ::: Liveness probe
foo foo Sat Nov 21 03:53:01 UTC 2020 ::: Readiness probe
foo foo Sat Nov 21 03:53:11 UTC 2020 ::: Readiness probe
- foo › foo
+ foo › foo
foo foo Sat Nov 21 03:53:31 UTC 2020 ::: Readiness probe
foo foo Sat Nov 21 03:53:31 UTC 2020 ::: Liveness probe
foo foo Sat Nov 21 03:53:41 UTC 2020 ::: Readiness probe
foo foo Sat Nov 21 03:53:41 UTC 2020 ::: Liveness probe
```

## Case 2

**Preparing**
```sh
cat <<'EOL' | kubectl apply -f-
apiVersion: v1
kind: Pod
metadata:
  name: bar
spec:
  shareProcessNamespace: true
  containers:
    - name: bar
      image: busybox
      command: ["sh", "-c", "while true; do echo $(date); sleep 1; done"]
EOL
```
**Before**
```sh
# terminal 1
$ stern bar
+ bar › bar
bar bar Sat Nov 21 04:13:30 UTC 2020
bar bar Sat Nov 21 04:13:31 UTC 2020
bar bar Sat Nov 21 04:13:32 UTC 2020
bar bar Sat Nov 21 04:13:33 UTC 2020
bar bar Sat Nov 21 04:13:34 UTC 2020
bar bar Sat Nov 21 04:13:35 UTC 2020
bar bar Sat Nov 21 04:13:36 UTC 2020
bar bar Sat Nov 21 04:13:37 UTC 2020
bar bar
# <---- Do not follow logs of the restarted container
```

```sh
# terminal 2
$ kubectl exec bar -- sh -c 'kill 1'
```

**After**
```sh
$ dist/stern bar
bar bar Sat Nov 21 04:14:48 UTC 2020
bar bar Sat Nov 21 04:14:49 UTC 2020
bar bar Sat Nov 21 04:14:50 UTC 2020
bar bar Sat Nov 21 04:14:51 UTC 2020
bar bar Sat Nov 21 04:14:52 UTC 2020
bar bar Sat Nov 21 04:14:53 UTC 2020
bar bar Sat Nov 21 04:14:54 UTC 2020
- bar › bar
+ bar › bar
bar bar Sat Nov 21 04:15:09 UTC 2020
bar bar Sat Nov 21 04:15:10 UTC 2020
bar bar Sat Nov 21 04:15:11 UTC 2020
bar bar Sat Nov 21 04:15:12 UTC 2020
bar bar Sat Nov 21 04:15:13 UTC 2020
```