### PR TITLE
Fix mixed log lines

### DIFF
--- a/stern/tail.go
+++ b/stern/tail.go
@@ -16,6 +16,7 @@ package stern
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"hash/fnv"
@@ -202,9 +203,14 @@ func (t *Tail) Print(msg string, out io.Writer) {
 		PodColor:       t.podColor,
 		ContainerColor: t.containerColor,
 	}
-	if err := t.tmpl.Execute(out, vm); err != nil {
+
+	var buf bytes.Buffer
+	if err := t.tmpl.Execute(&buf, vm); err != nil {
 		fmt.Fprintf(os.Stderr, "expanding template failed: %s\n", err)
+		return
 	}
+
+	fmt.Fprint(out, buf.String())
 }
 
 // isActive returns false if the log stream is closed.


### PR DESCRIPTION
> A template may be executed safely in parallel, although if parallel
executions share a Writer the output may be interleaved.

- https://golang.org/pkg/text/template/#Template.Execute

For the above reason, the result of the template's execution must be
stored in a buffer once.

Fixed #104 