### PR TITLE
Update doc for --since default

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The `pod` query is a regular expression so you could provide `"web-\w"` to tail
 | `--namespace`, `-n`        |                  | Kubernetes namespace to use. Default to namespace configured in Kubernetes context                           |
 | `--output`, `-o`           | `default`        | Specify predefined template. Currently support: [default, raw, json] See templates section                   |
 | `--selector`, `-l`         |                  | Selector (label query) to filter on. If present, default to `.*` for the pod-query.                          |
-| `--since`, `-s`            |                  | Return logs newer than a relative duration like 5s, 2m, or 3h. Displays all if omitted                       |
+| `--since`, `-s`            | `48h`            | Return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to 48h.                              |
 | `--tail`                   | `-1`             | The number of lines from the end of the logs to show. Defaults to -1, showing all logs.                      |
 | `--template`               |                  | Template to use for log lines, leave empty to use --output flag                                              |
 | `--timestamps`, `-t`       |                  | Print timestamps                                                                                             |


### PR DESCRIPTION
I noticed the documentation of the `--since` flag doesn't reflect the actual behavior. This PR proposes an update taken from the command `help`.
I haven't created an issue for this being a very minor change to the docs. Please let me know if that's needed anyway.

PS: I'm a happy user of `stern`, thanks a lot for this tool.