### PR TITLE
Use GITHUB_TOKEN to authenticate with ghcr.io

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,8 +22,8 @@ jobs:
       uses: docker/login-action@v1
       with:
         registry: ghcr.io
-        username: stern-robot
-        password: ${{ secrets.CR_PAT }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Release
       run: make release
       env:


### PR DESCRIPTION
ghcr.io now supports GITHUB_TOKEN.

https://github.blog/changelog/2021-03-24-packages-container-registry-now-supports-github_token/