### PR TITLE
Add --timezone option to set timestamps to specific timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The `pod` query is a regular expression so you could provide `"web-\w"` to tail
 | `--tail`                    | `-1`       | The number of lines from the end of the logs to show. Defaults to -1, showing all logs.                                                                            |
 | `--template`                |            | Template to use for log lines, leave empty to use --output flag                                                                                                    |
 | `--timestamps`, `-t`        |            | Print timestamps                                                                                                                                                   |
+| `--timezone`                | `Local`    | Set timestamps to specific timezone. Defaults to `Local`.                                                                                                          |
 | `--version`, `-v`           |            | Print the version and exit                                                                                                                                         |
 
 See `stern --help` for details
@@ -131,6 +132,11 @@ stern -n staging --exclude-container istio-proxy .
 Show auth activity from 15min ago with timestamps
 ```
 stern auth -t --since 15m
+```
+
+Show auth activity with timestamps in specific timezone (default is your local timezone)
+```
+stern auth -t --timezone Asia/Tokyo
 ```
 
 Follow the development of `some-new-feature` in minikube

--- a/stern/config.go
+++ b/stern/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	Namespaces            []string
 	PodQuery              *regexp.Regexp
 	Timestamps            bool
+	Location              *time.Location
 	ContainerQuery        *regexp.Regexp
 	ExcludeContainerQuery *regexp.Regexp
 	ContainerState        ContainerState

--- a/stern/stern.go
+++ b/stern/stern.go
@@ -134,6 +134,7 @@ func Run(ctx context.Context, config *Config) error {
 
 			tail := NewTail(clientset, p.Node, p.Namespace, p.Pod, p.Container, config.Template, os.Stdout, os.Stderr, &TailOptions{
 				Timestamps:   config.Timestamps,
+				Location:     config.Location,
 				SinceSeconds: int64(config.Since.Seconds()),
 				Exclude:      config.Exclude,
 				Include:      config.Include,


### PR DESCRIPTION
`--timezone` option sets timestamps to a specific time zone. The default
timezone is changed to your locale from UTC, so this is a breaking
change.

Print timestamps with your local timezone:
```
stern . --timestamps
```

Print timestamps with specific timezone:
```
stern . -t --timezone Europe/Paris
```

`TZ` environment also can be used:
```
TZ=Europe/Paris stern . -t
```

Closes #43 