### PR TITLE
Fix "interface conversion: runtime.Object is *v1.Status, not *v1.Pod"

### DIFF
--- a/stern/watch.go
+++ b/stern/watch.go
@@ -65,7 +65,10 @@ func Watch(ctx context.Context, i v1.PodInterface, podFilter *regexp.Regexp, con
 					return
 				}
 
-				pod := e.Object.(*corev1.Pod)
+				pod, ok := e.Object.(*corev1.Pod)
+				if !ok {
+					continue
+				}
 
 				if !podFilter.MatchString(pod.Name) {
 					continue


### PR DESCRIPTION
If type conversion to a Pod object fails, skip the process.

ref/ #117 