### PR TITLE
Make init container flag message more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The `pod` query is a regular expression so you could provide `"web-\w"` to tail
 | `--exclude-pod`             |            | Pod name to exclude (regular expression)                                                                                                                           |
 | `--help`, `-h`              |            | Output Usage and Flags details                                                                                                                                     |
 | `--include`, `-i`           |            | Log lines to include; specify multiple with additional `--include`; (regular expression)                                                                           |
-| `--init-containers`         | `true`     | Include or exclude init containers                                                                                                                                 |
+| `--init-containers`         | `true`     | Include init containers                                                                                                                                 |
 | `--ephemeral-containers`    | `true`     | Include or exclude ephemeral containers                                                                                                                            |
 | `--kubeconfig`              | *see note* | Path to kubeconfig file to use. Default to `KUBECONFIG` variable then `~/.kube/config` path                                                                        |
 | `--namespace`, `-n`         |            | Kubernetes namespace to use. Default to namespace configured in Kubernetes context. To watch multiple namespaces, repeat this flag or set comma-separated value.   |

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -98,7 +98,7 @@ func Run() {
 	_ = cmd.Flags().MarkDeprecated("kube-config", "Use --kubeconfig instead.")
 	cmd.Flags().StringSliceVarP(&opts.exclude, "exclude", "e", opts.exclude, "Regex of log lines to exclude")
 	cmd.Flags().StringSliceVarP(&opts.include, "include", "i", opts.include, "Regex of log lines to include")
-	cmd.Flags().BoolVar(&opts.initContainers, "init-containers", opts.initContainers, "Include or exclude init containers")
+	cmd.Flags().BoolVar(&opts.initContainers, "init-containers", opts.initContainers, "Include init containers")
 	cmd.Flags().BoolVar(&opts.ephemeralContainers, "ephemeral-containers", opts.ephemeralContainers, "Include or exclude ephemeral containers")
 	cmd.Flags().BoolVarP(&opts.allNamespaces, "all-namespaces", "A", opts.allNamespaces, "If present, tail across all namespaces. A specific namespace is ignored even if specified with --namespace.")
 	cmd.Flags().StringVarP(&opts.selector, "selector", "l", opts.selector, "Selector (label query) to filter on. If present, default to \".*\" for the pod-query.")


### PR DESCRIPTION
## What

This flag include or exclude the init container and the default value is `true`.

It's hard to understand wether **is it going to get included or excluded** because the messages are confusing. Therefore, I propose to make it clear by removing the `or exclude` term.