### PR TITLE
Generate cli flags section on README.md

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,8 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
+    - name: Run verify-readme
+      run: make verify-readme
     - name: Run tests
       run: make test
     - name: Build binary

--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,15 @@ fmt:
 vet:
 	go vet ./...
 
+README_FILE ?= ./README.md
+
 .PHONY: update-readme
 update-readme:
-	$(GO) run hack/update-readme/update-readme.go ./README.md
+	$(GO) run hack/update-readme/update-readme.go $(README_FILE)
+
+.PHONY: verify-readme
+verify-readme:
+	./hack/verify-readme.sh
 
 .PHONY: dist
 dist: $(GORELEASER)

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,10 @@ fmt:
 vet:
 	go vet ./...
 
+.PHONY: update-readme
+update-readme:
+	$(GO) run hack/update-readme/update-readme.go ./README.md
+
 .PHONY: dist
 dist: $(GORELEASER)
 	$(GORELEASER) release --rm-dist --skip-publish --snapshot

--- a/README.md
+++ b/README.md
@@ -53,32 +53,33 @@ The `pod` query is a regular expression so you could provide `"web-\w"` to tail
 
 ### cli flags
 
-| flag                        | default    | purpose                                                                                                                                                            |
-|-----------------------------|------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `--all-namespaces`, `-A`    |            | If present, tail across all namespaces. A specific namespace is ignored even if specified with --namespace.                                                        |
-| `--color`                   | `auto`     | Force set color output. `auto`: colorize if tty attached, `always`: always colorize, `never`: never colorize                                                       |
-| `--completion`              |            | Outputs stern command-line completion code for the specified shell. Can be 'bash' or 'zsh'                                                                         |
-| `--container`, `-c`         | `.*`       | Container name when multiple containers in pod (regular expression)                                                                                                |
-| `--container-state`         | `running`  | Tail containers with state in running, waiting or terminated. Default to running. To watch multiple states, repeat this flag or set comma-separated value.         |
-| `--context`                 |            | Kubernetes context to use. Default to `kubectl config current-context`                                                                                             |
-| `--exclude`, `-e`           |            | Log lines to exclude; specify multiple with additional `--exclude`; (regular expression)                                                                           |
-| `--exclude-container`, `-E` |            | Container name to exclude when multiple containers in pod (regular expression)                                                                                     |
-| `--exclude-pod`             |            | Pod name to exclude (regular expression)                                                                                                                           |
-| `--help`, `-h`              |            | Output Usage and Flags details                                                                                                                                     |
-| `--include`, `-i`           |            | Log lines to include; specify multiple with additional `--include`; (regular expression)                                                                           |
-| `--init-containers`         | `true`     | Include init containers                                                                                                                                 |
-| `--ephemeral-containers`    | `true`     | Include or exclude ephemeral containers                                                                                                                            |
-| `--kubeconfig`              | *see note* | Path to kubeconfig file to use. Default to `KUBECONFIG` variable then `~/.kube/config` path                                                                        |
-| `--namespace`, `-n`         |            | Kubernetes namespace to use. Default to namespace configured in Kubernetes context. To watch multiple namespaces, repeat this flag or set comma-separated value.   |
-| `--output`, `-o`            | `default`  | Specify predefined template. Currently support: [default, raw, json] See templates section                                                                         |
-| `--selector`, `-l`          |            | Selector (label query) to filter on. If present, default to `.*` for the pod-query.                                                                                |
-| `--field-selector`          |            | Selector (field query) to filter on. If present, default to `.*` for the pod-query.                                                                                |
-| `--since`, `-s`             | `48h`      | Return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to 48h.                                                                                    |
-| `--tail`                    | `-1`       | The number of lines from the end of the logs to show. Defaults to -1, showing all logs.                                                                            |
-| `--template`                |            | Template to use for log lines, leave empty to use --output flag                                                                                                    |
-| `--timestamps`, `-t`        |            | Print timestamps                                                                                                                                                   |
-| `--timezone`                | `Local`    | Set timestamps to specific timezone. Defaults to `Local`.                                                                                                          |
-| `--version`, `-v`           |            | Print the version and exit                                                                                                                                         |
+<!-- auto generated cli flags begin --->
+ flag                        | default   | purpose
+-----------------------------|-----------|---------
+ `--all-namespaces`, `-A`    | `false`   | If present, tail across all namespaces. A specific namespace is ignored even if specified with --namespace.
+ `--color`                   | `auto`    | Force set color output. 'auto':  colorize if tty attached, 'always': always colorize, 'never': never colorize.
+ `--completion`              |           | Output stern command-line completion code for the specified shell. Can be 'bash' or 'zsh'.
+ `--container`, `-c`         | `.*`      | Container name when multiple containers in pod. (regular expression)
+ `--container-state`         | `running` | Tail containers with state in running, waiting or terminated. To specify multiple states, repeat this or set comma-separated value.
+ `--context`                 |           | Kubernetes context to use. Default to current context configured in kubeconfig.
+ `--ephemeral-containers`    | `true`    | Include or exclude ephemeral containers.
+ `--exclude`, `-e`           |           | Log lines to exclude. (regular expression)
+ `--exclude-container`, `-E` |           | Container name to exclude when multiple containers in pod. (regular expression)
+ `--exclude-pod`             |           | Pod name to exclude. (regular expression)
+ `--field-selector`          |           | Selector (field query) to filter on. If present, default to ".*" for the pod-query.
+ `--include`, `-i`           |           | Log lines to include. (regular expression
+ `--init-containers`         | `true`    | Include or exclude init containers.
+ `--kubeconfig`              |           | Path to kubeconfig file to use. Default to KUBECONFIG variable then ~/.kube/config path.
+ `--namespace`, `-n`         |           | Kubernetes namespace to use. Default to namespace configured in kubernetes context. To specify multiple namespaces, repeat this or set comma-separated value.
+ `--output`, `-o`            | `default` | Specify predefined template. Currently support: [default, raw, json]
+ `--selector`, `-l`          |           | Selector (label query) to filter on. If present, default to ".*" for the pod-query.
+ `--since`, `-s`             | `48h0m0s` | Return logs newer than a relative duration like 5s, 2m, or 3h.
+ `--tail`                    | `-1`      | The number of lines from the end of the logs to show. Defaults to -1, showing all logs.
+ `--template`                |           | Template to use for log lines, leave empty to use --output flag.
+ `--timestamps`, `-t`        | `false`   | Print timestamps.
+ `--timezone`                | `Local`   | Set timestamps to specific timezone.
+ `--version`, `-v`           | `false`   | Print the version and exit.
+<!-- auto generated cli flags end --->
 
 See `stern --help` for details
 

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -67,16 +67,16 @@ type Options struct {
 }
 
 var opts = &Options{
+	color:               "auto",
 	container:           ".*",
 	containerStates:     []string{"running"},
-	timestamps:          false,
-	timezone:            "Local",
 	initContainers:      true,
 	ephemeralContainers: true,
-	tail:                -1,
-	color:               "auto",
-	template:            "",
 	output:              "default",
+	tail:                -1,
+	template:            "",
+	timestamps:          false,
+	timezone:            "Local",
 }
 
 func Run() {

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/stern/stern/stern"
 
 	"github.com/fatih/color"
@@ -85,31 +86,7 @@ func Run() {
 	cmd.Use = "stern pod-query"
 	cmd.Short = "Tail multiple pods and containers from Kubernetes"
 
-	cmd.Flags().StringVar(&opts.excludePod, "exclude-pod", opts.excludePod, "Regex of pod query to exclude")
-	cmd.Flags().StringVarP(&opts.container, "container", "c", opts.container, "Container name when multiple containers in pod")
-	cmd.Flags().StringVarP(&opts.excludeContainer, "exclude-container", "E", opts.excludeContainer, "Exclude a Container name")
-	cmd.Flags().StringSliceVar(&opts.containerStates, "container-state", opts.containerStates, "If present, tail containers with state in running, waiting or terminated. Default to running. To specify multiple states, repeat this or set comma-separated value.")
-	cmd.Flags().BoolVarP(&opts.timestamps, "timestamps", "t", opts.timestamps, "Print timestamps")
-	cmd.Flags().StringVar(&opts.timezone, "timezone", opts.timezone, "Set timestamps to specific timezone")
-	cmd.Flags().DurationVarP(&opts.since, "since", "s", opts.since, "Return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to 48h.")
-	cmd.Flags().StringVar(&opts.context, "context", opts.context, "Kubernetes context to use. Default to current context configured in kubeconfig.")
-	cmd.Flags().StringSliceVarP(&opts.namespaces, "namespace", "n", opts.namespaces, "Kubernetes namespace to use. Default to namespace configured in Kubernetes context. To specify multiple namespaces, repeat this or set comma-separated value.")
-	cmd.Flags().StringVar(&opts.kubeConfig, "kubeconfig", opts.kubeConfig, "Path to kubeconfig file to use")
-	cmd.Flags().StringVar(&opts.kubeConfig, "kube-config", opts.kubeConfig, "Path to kubeconfig file to use")
-	_ = cmd.Flags().MarkDeprecated("kube-config", "Use --kubeconfig instead.")
-	cmd.Flags().StringSliceVarP(&opts.exclude, "exclude", "e", opts.exclude, "Regex of log lines to exclude")
-	cmd.Flags().StringSliceVarP(&opts.include, "include", "i", opts.include, "Regex of log lines to include")
-	cmd.Flags().BoolVar(&opts.initContainers, "init-containers", opts.initContainers, "Include init containers")
-	cmd.Flags().BoolVar(&opts.ephemeralContainers, "ephemeral-containers", opts.ephemeralContainers, "Include or exclude ephemeral containers")
-	cmd.Flags().BoolVarP(&opts.allNamespaces, "all-namespaces", "A", opts.allNamespaces, "If present, tail across all namespaces. A specific namespace is ignored even if specified with --namespace.")
-	cmd.Flags().StringVarP(&opts.selector, "selector", "l", opts.selector, "Selector (label query) to filter on. If present, default to \".*\" for the pod-query.")
-	cmd.Flags().StringVar(&opts.fieldSelector, "field-selector", opts.fieldSelector, "Selector (field query) to filter on. If present, default to \".*\" for the pod-query.")
-	cmd.Flags().Int64Var(&opts.tail, "tail", opts.tail, "The number of lines from the end of the logs to show. Defaults to -1, showing all logs.")
-	cmd.Flags().StringVar(&opts.color, "color", opts.color, "Color output. Can be 'always', 'never', or 'auto'")
-	cmd.Flags().BoolVarP(&opts.version, "version", "v", opts.version, "Print the version and exit")
-	cmd.Flags().StringVar(&opts.completion, "completion", opts.completion, "Outputs stern command-line completion code for the specified shell. Can be 'bash' or 'zsh'")
-	cmd.Flags().StringVar(&opts.template, "template", opts.template, "Template to use for log lines, leave empty to use --output flag")
-	cmd.Flags().StringVarP(&opts.output, "output", "o", opts.output, "Specify predefined template. Currently support: [default, raw, json]")
+	AddFlags(cmd.Flags())
 
 	// Specify custom bash completion function
 	cmd.BashCompletionFunction = bash_completion_func
@@ -160,6 +137,35 @@ func Run() {
 	if err := cmd.Execute(); err != nil {
 		log.Fatal(err)
 	}
+}
+
+// AddFlags adds all the flags used by stern.
+func AddFlags(fs *pflag.FlagSet) {
+	fs.BoolVarP(&opts.allNamespaces, "all-namespaces", "A", opts.allNamespaces, "If present, tail across all namespaces. A specific namespace is ignored even if specified with --namespace.")
+	fs.StringVar(&opts.color, "color", opts.color, "Force set color output. 'auto':  colorize if tty attached, 'always': always colorize, 'never': never colorize.")
+	fs.StringVar(&opts.completion, "completion", opts.completion, "Output stern command-line completion code for the specified shell. Can be 'bash' or 'zsh'.")
+	fs.StringVarP(&opts.container, "container", "c", opts.container, "Container name when multiple containers in pod. (regular expression)")
+	fs.StringSliceVar(&opts.containerStates, "container-state", opts.containerStates, "Tail containers with state in running, waiting or terminated. To specify multiple states, repeat this or set comma-separated value.")
+	fs.StringVar(&opts.context, "context", opts.context, "Kubernetes context to use. Default to current context configured in kubeconfig.")
+	fs.StringSliceVarP(&opts.exclude, "exclude", "e", opts.exclude, "Log lines to exclude. (regular expression)")
+	fs.StringVarP(&opts.excludeContainer, "exclude-container", "E", opts.excludeContainer, "Container name to exclude when multiple containers in pod. (regular expression)")
+	fs.StringVar(&opts.excludePod, "exclude-pod", opts.excludePod, "Pod name to exclude. (regular expression)")
+	fs.StringSliceVarP(&opts.include, "include", "i", opts.include, "Log lines to include. (regular expression")
+	fs.BoolVar(&opts.initContainers, "init-containers", opts.initContainers, "Include or exclude init containers.")
+	fs.BoolVar(&opts.ephemeralContainers, "ephemeral-containers", opts.ephemeralContainers, "Include or exclude ephemeral containers.")
+	fs.StringVar(&opts.kubeConfig, "kubeconfig", opts.kubeConfig, "Path to kubeconfig file to use. Default to KUBECONFIG variable then ~/.kube/config path.")
+	fs.StringVar(&opts.kubeConfig, "kube-config", opts.kubeConfig, "Path to kubeconfig file to use.")
+	_ = fs.MarkDeprecated("kube-config", "Use --kubeconfig instead.")
+	fs.StringSliceVarP(&opts.namespaces, "namespace", "n", opts.namespaces, "Kubernetes namespace to use. Default to namespace configured in kubernetes context. To specify multiple namespaces, repeat this or set comma-separated value.")
+	fs.StringVarP(&opts.output, "output", "o", opts.output, "Specify predefined template. Currently support: [default, raw, json]")
+	fs.StringVarP(&opts.selector, "selector", "l", opts.selector, "Selector (label query) to filter on. If present, default to \".*\" for the pod-query.")
+	fs.StringVar(&opts.fieldSelector, "field-selector", opts.fieldSelector, "Selector (field query) to filter on. If present, default to \".*\" for the pod-query.")
+	fs.DurationVarP(&opts.since, "since", "s", opts.since, "Return logs newer than a relative duration like 5s, 2m, or 3h.")
+	fs.Int64Var(&opts.tail, "tail", opts.tail, "The number of lines from the end of the logs to show. Defaults to -1, showing all logs.")
+	fs.StringVar(&opts.template, "template", opts.template, "Template to use for log lines, leave empty to use --output flag.")
+	fs.BoolVarP(&opts.timestamps, "timestamps", "t", opts.timestamps, "Print timestamps.")
+	fs.StringVar(&opts.timezone, "timezone", opts.timezone, "Set timestamps to specific timezone.")
+	fs.BoolVarP(&opts.version, "version", "v", opts.version, "Print the version and exit.")
 }
 
 func parseConfig(args []string) (*stern.Config, error) {

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -73,6 +73,7 @@ var opts = &Options{
 	initContainers:      true,
 	ephemeralContainers: true,
 	output:              "default",
+	since:               48 * time.Hour,
 	tail:                -1,
 	template:            "",
 	timestamps:          false,
@@ -298,10 +299,6 @@ func parseConfig(args []string) (*stern.Config, error) {
 	template, err := template.New("log").Funcs(funs).Parse(t)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to parse template")
-	}
-
-	if opts.since == 0 {
-		opts.since = 172800000000000 // 48h
 	}
 
 	namespaces := []string{}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/fatih/color v1.9.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.1.1
+	github.com/spf13/pflag v1.0.5
 	k8s.io/api v0.21.0
 	k8s.io/apimachinery v0.21.0
 	k8s.io/client-go v0.21.0

--- a/hack/update-readme/update-readme.go
+++ b/hack/update-readme/update-readme.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/stern/stern/cmd"
+)
+
+const (
+	targetSectionBegin = "<!-- auto generated cli flags begin --->"
+	targetSectionEnd   = "<!-- auto generated cli flags end --->"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "readmePath argument required")
+		os.Exit(1)
+	}
+	readmePath := os.Args[1]
+
+	flagsMarkdownTable := GenerateFlagsMarkdownTable()
+
+	readmeString, err := GenerateReadme(readmePath, flagsMarkdownTable)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	err = OverwriteReadme(readmePath, readmeString)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+// GenerateFlagsMarkdownTable generates markdown table of flag list.
+// This function loads flag list and generates such as following text:
+//  flag            | default         | purpose
+// -----------------|-----------------|---------
+//  `--flag1`, `-f` |                 | This is flag1.
+//  `--flag2`       | `flag2-default` | This is flag2.
+func GenerateFlagsMarkdownTable() string {
+	c := &cobra.Command{}
+	cmd.AddFlags(c.Flags())
+	allFlags := c.NonInheritedFlags()
+
+	flagMaxlen, defaultMaxlen := len(" flag "), len(" default ")
+	allTexts := make([][]string, 0)
+	allFlags.VisitAll(func(flag *pflag.Flag) {
+		// won't append deprecated flag
+		if flag.Deprecated != "" {
+			return
+		}
+
+		flagText := ""
+		if flag.Shorthand != "" {
+			flagText = fmt.Sprintf(" `--%s`, `-%s` ", flag.Name, flag.Shorthand)
+		} else {
+			flagText = fmt.Sprintf(" `--%s` ", flag.Name)
+		}
+		if len(flagText) > flagMaxlen {
+			flagMaxlen = len(flagText)
+		}
+
+		flagTypeName, usage := pflag.UnquoteUsage(flag)
+		defaultText := ""
+		if flag.DefValue != "" {
+			switch flagTypeName {
+			// convert []string{"aaa", "bbb"} to "aaa,bbb"
+			case "strings":
+				stirngSlice, err := allFlags.GetStringSlice(flag.Name)
+				if err != nil {
+					panic(err)
+				}
+
+				defaultValuesString := ""
+				for _, s := range stirngSlice {
+					defaultValuesString += fmt.Sprintf("%s,", s)
+				}
+				defaultValuesString = strings.TrimRight(defaultValuesString, ",")
+
+				if defaultValuesString != "" {
+					defaultText += fmt.Sprintf(" `%s` ", defaultValuesString)
+				}
+			default:
+				defaultText += fmt.Sprintf(" `%s` ", flag.DefValue)
+			}
+		}
+		if len(defaultText) > defaultMaxlen {
+			defaultMaxlen = len(defaultText)
+		}
+
+		purposeText := fmt.Sprintf(" %s", usage)
+
+		allTexts = append(allTexts, []string{flagText, defaultText, purposeText})
+	})
+
+	tableText := fmt.Sprintf(
+		" flag %s| default %s| purpose\n",
+		strings.Repeat(" ", flagMaxlen-len(" flag ")),
+		strings.Repeat(" ", defaultMaxlen-len(" default ")))
+	tableText += fmt.Sprintf(
+		"%s|%s|%s\n",
+		strings.Repeat("-", flagMaxlen),
+		strings.Repeat("-", defaultMaxlen),
+		strings.Repeat("-", len(" purpose ")))
+	for _, text := range allTexts {
+		tableText += text[0]
+		tableText += strings.Repeat(" ", flagMaxlen-len(text[0]))
+		tableText += "|" + text[1]
+		tableText += strings.Repeat(" ", defaultMaxlen-len(text[1]))
+		tableText += "|" + text[2]
+		tableText += "\n"
+	}
+
+	return tableText
+}
+
+// GenerateReadme generates README.md in which flags markdown table is embedded.
+// Overwrite the section which specified as the target.
+func GenerateReadme(readmePath, flagsMarkdownTable string) (string, error) {
+	f, err := os.Open(readmePath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	buf, err := io.ReadAll(f)
+	if err != nil {
+		return "", err
+	}
+
+	inTargetSection := false
+	tableText := ""
+	scanner := bufio.NewScanner(strings.NewReader(string(buf)))
+	for scanner.Scan() {
+		if !inTargetSection {
+			tableText += scanner.Text() + "\n"
+		}
+
+		if scanner.Text() == targetSectionBegin {
+			inTargetSection = true
+		}
+
+		if scanner.Text() == targetSectionEnd {
+			tableText += flagsMarkdownTable
+			tableText += scanner.Text() + "\n"
+			inTargetSection = false
+		}
+	}
+
+	return tableText, nil
+}
+
+// OverwriteReadme overwrites README.md with passed readmeString.
+func OverwriteReadme(readmePath, readmeString string) error {
+	f, err := os.Create(readmePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = f.WriteString(readmeString)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/hack/verify-readme.sh
+++ b/hack/verify-readme.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -eo pipefail; [[ -n "$DEBUG" ]] && set -ux
+
+ROOT_DIR="$(cd "$(dirname $0)" && pwd)/.."
+cd "$ROOT_DIR"
+
+tempfile="$(mktemp)"
+cat README.md >"$tempfile"
+make update-readme README_FILE="$tempfile" >/dev/null
+diff="$(diff -u ./README.md "$tempfile" ||:)"
+
+if [[ -n "$diff" ]]; then
+  echo "$diff" >&2
+  echo "Error: Running update-readme made a difference in README.md." >&2
+  echo "Maybe you forgot to run 'make update-readme'." >&2
+  exit 1
+fi


### PR DESCRIPTION
resolves: #130

Implement `make update-readme` and `make verify-readme`.

`make update-readme` generates cli flags list markdown table from `cli.go` and overwrites `README.md`.

`make verify-readme` makes sure that `README.md` is up to date.

Please let me know if there are any problem:pray: