### PR TITLE
Fix "unexpected error: parsing time" error during parsing the logs

### DIFF
--- a/stern/tail.go
+++ b/stern/tail.go
@@ -90,13 +90,18 @@ func (o TailOptions) UpdateTimezoneIfNeeded(message string) (string, error) {
 		return message, nil
 	}
 
-	datetime := message[:30]
+	idx := strings.IndexRune(message, ' ')
+	if idx == -1 {
+		return "", fmt.Errorf("A log message does not seem to have a datetime prefix: %s", message)
+	}
+
+	datetime := message[:idx]
 	t, err := time.ParseInLocation(time.RFC3339Nano, datetime, time.UTC)
 	if err != nil {
 		return "", err
 	}
 
-	return t.In(o.Location).Format("2006-01-02T15:04:05.000000000Z07:00") + message[30:], nil
+	return t.In(o.Location).Format("2006-01-02T15:04:05.000000000Z07:00") + message[idx:], nil
 }
 
 // NewTail returns a new tail for a Kubernetes container inside a pod

--- a/stern/tail_test.go
+++ b/stern/tail_test.go
@@ -103,6 +103,26 @@ func TestUpdateTimezoneIfNeeded(t *testing.T) {
 			"Connection: keep-alive",
 			"",
 		},
+		{
+			"not UTC",
+			&TailOptions{
+				Timestamps: true,
+				Location:   location,
+			},
+			"2021-08-03T01:26:29.953994922+02:00 Connection: keep-alive",
+			"2021-08-03T08:26:29.953994922+09:00 Connection: keep-alive",
+			"",
+		},
+		{
+			"RFC3339Nano format removed trailing zeros",
+			&TailOptions{
+				Timestamps: true,
+				Location:   location,
+			},
+			"2021-06-20T08:20:30.331385Z Connection: keep-alive",
+			"2021-06-20T17:20:30.331385000+09:00 Connection: keep-alive",
+			"",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR fixes Fix "unexpected error: parsing time" error during parsing the logs from pods.

Fixes #137