### PR TITLE
Add a new function `parseJSON` to --template flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,11 +114,11 @@ will receive the following struct:
 The following functions are available within the template (besides the [builtin
 functions](https://golang.org/pkg/text/template/#hdr-Functions)):
 
-| func    | arguments             | description                                                     |
-|---------|-----------------------|-----------------------------------------------------------------|
-| `json`  | `object`              | Marshal the object and output it as a json text                 |
-| `color` | `color.Color, string` | Wrap the text in color (.ContainerColor and .PodColor provided) |
-
+| func        | arguments             | description                                                     |
+|-------------|-----------------------|-----------------------------------------------------------------|
+| `json`      | `object`              | Marshal the object and output it as a json text                 |
+| `color`     | `color.Color, string` | Wrap the text in color (.ContainerColor and .PodColor provided) |
+| `parseJSON` | `string`              | Parse string as JSON                                            |
 
 
 ## Examples:
@@ -193,6 +193,12 @@ Output using a custom template with stern-provided colors:
 
 ```
 stern --template '{{.Message}} ({{.Namespace}}/{{color .PodColor .PodName}}/{{color .ContainerColor .ContainerName}}){{"\n"}}' backend
+```
+
+Output using a custom template with `parseJSON`:
+
+```
+stern . --template='{{.PodName}}/{{.ContainerName}} {{with $d := .Message | parseJSON}}[{{$d.level}}] {{$d.message}}{{end}}{{"\n"}}' backend
 ```
 
 Trigger the interactive prompt to select an 'app.kubernetes.io/instance' label value:

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -239,6 +239,13 @@ func (o *options) sternConfig() (*stern.Config, error) {
 			}
 			return string(b), nil
 		},
+		"parseJSON": func(text string) (map[string]interface{}, error) {
+			obj := make(map[string]interface{})
+			if err := json.Unmarshal([]byte(text), &obj); err != nil {
+				return obj, err
+			}
+			return obj, nil
+		},
 		"color": func(color color.Color, text string) string {
 			return color.SprintFunc()(text)
 		},


### PR DESCRIPTION
`parseJSON` function parses string as JSON.

For example, if an application outputs the following log message:

```
{"level": "INFO", "message": "This is log message"}
```

We can use `parseJSON` function to format logs as follows:

```
$ stern . --template='{{.PodName}}/{{.ContainerName}} {{with $d := .Message | parseJSON}}[{{$d.level}}] {{$d.message}}{{end}}{{"\n"}}'
app-544bbcd5dc-fwgdj/application [INFO] This is log message
```

You can try this new function using the following steps:
```
cat <<EOL | kubectl apply -f-
apiVersion: apps/v1
kind: Deployment
metadata:
  name: app
spec:
  selector:
    matchLabels:
      app: app
  template:
    metadata:
      labels:
        app: app
    spec:
      containers:
      - image: busybox
        name: application
        command: ["/bin/sh"]
        args:
        - -c
        - |-
          while true; do
            echo '{"level": "INFO", "message": "This is log message"}'
            sleep 1
          done
EOL

stern . --template='{{.PodName}}/{{.ContainerName}} {{with $d := .Message | parseJSON}}[{{$d.level}}] {{$d.message}}{{end}}{{"\n"}}'
```

Closes https://github.com/stern/stern/issues/22