### PR TITLE
Add and export follow option to TailOptions

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -287,6 +287,7 @@ func (o *options) sternConfig() (*stern.Config, error) {
 		FieldSelector:         fieldSelector,
 		TailLines:             tailLines,
 		Template:              template,
+		Follow:                true,
 
 		Out:    o.Out,
 		ErrOut: o.ErrOut,

--- a/stern/config.go
+++ b/stern/config.go
@@ -46,6 +46,7 @@ type Config struct {
 	FieldSelector         fields.Selector
 	TailLines             *int64
 	Template              *template.Template
+	Follow                bool
 
 	Out    io.Writer
 	ErrOut io.Writer

--- a/stern/stern.go
+++ b/stern/stern.go
@@ -141,6 +141,7 @@ func Run(ctx context.Context, config *Config) error {
 				Include:      config.Include,
 				Namespace:    config.AllNamespaces || len(namespaces) > 1,
 				TailLines:    config.TailLines,
+				Follow:       config.Follow,
 			})
 			setTail(targetID, tail)
 

--- a/stern/tail.go
+++ b/stern/tail.go
@@ -59,6 +59,7 @@ type TailOptions struct {
 	Include      []*regexp.Regexp
 	Namespace    bool
 	TailLines    *int64
+	Follow       bool
 }
 
 func (o TailOptions) IsExclude(msg string) bool {
@@ -92,7 +93,7 @@ func (o TailOptions) UpdateTimezoneIfNeeded(message string) (string, error) {
 
 	idx := strings.IndexRune(message, ' ')
 	if idx == -1 {
-		return "", fmt.Errorf("A log message does not seem to have a datetime prefix: %s", message)
+		return "", fmt.Errorf("a log message does not seem to have a datetime prefix: %s", message)
 	}
 
 	datetime := message[:idx]
@@ -159,7 +160,7 @@ func (t *Tail) Start(ctx context.Context) error {
 	}
 
 	req := t.clientset.Pods(t.Namespace).GetLogs(t.PodName, &corev1.PodLogOptions{
-		Follow:       true,
+		Follow:       t.Options.Follow,
 		Timestamps:   t.Options.Timestamps,
 		Container:    t.ContainerName,
 		SinceSeconds: &t.Options.SinceSeconds,


### PR DESCRIPTION
Hi guys,
I'm using stern as a lib inside the project [rpaas-operator](https://github.com/tsuru/rpaas-operator/blob/master/internal/pkg/rpaas/log.go) to log the pods of the CRD we manage... But it is of value to us to have the option to not always tail the logs and just print out the last N lines of logs from the instance, hence I made this PR to add this flexibility. 

cc: @nettoclaudio