### PR TITLE
Use "go install" instead of "go get"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Download a [binary release](https://github.com/stern/stern/releases)
 ### Build from source
 
 ```
-go get -u github.com/stern/stern
+go install github.com/stern/stern@latest
 ```
 
 ### asdf (Linux/macOS)


### PR DESCRIPTION
We can use `go install` command to install an executable binary since Go 1.16.