### PR TITLE
Disable uploading the krew plugin manifest using goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,18 +34,18 @@ dockers:
   - "ghcr.io/stern/stern:{{ .Major }}.{{ .Minor }}"
   - "ghcr.io/stern/stern:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
 krews:
-  - skip_upload: true
-    homepage: https://github.com/stern/stern
-    description: |
-      Stern allows you to `tail` multiple pods on Kubernetes and multiple containers
-      within the pod. Each result is color coded for quicker debugging.
+- skip_upload: true
+  homepage: https://github.com/stern/stern
+  description: |
+    Stern allows you to `tail` multiple pods on Kubernetes and multiple containers
+    within the pod. Each result is color coded for quicker debugging.
 
-      The query is a regular expression so the pod name can easily be filtered and
-      you don't need to specify the exact id (for instance omitting the deployment
-      id). If a pod is deleted it gets removed from tail and if a new pod is added it
-      automatically gets tailed.
+    The query is a regular expression so the pod name can easily be filtered and
+    you don't need to specify the exact id (for instance omitting the deployment
+    id). If a pod is deleted it gets removed from tail and if a new pod is added it
+    automatically gets tailed.
 
-      When a pod contains multiple containers Stern can tail all of them too without
-      having to do this manually for each one. Simply specify the `container` flag to
-      limit what containers to show. By default all containers are listened to.
-    short_description: Multi pod and container log tailing
+    When a pod contains multiple containers Stern can tail all of them too without
+    having to do this manually for each one. Simply specify the `container` flag to
+    limit what containers to show. By default all containers are listened to.
+  short_description: Multi pod and container log tailing

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,7 +34,7 @@ dockers:
   - "ghcr.io/stern/stern:{{ .Major }}.{{ .Minor }}"
   - "ghcr.io/stern/stern:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
 krews:
-  - skip_upload: false
+  - skip_upload: true
     homepage: https://github.com/stern/stern
     description: |
       Stern allows you to `tail` multiple pods on Kubernetes and multiple containers


### PR DESCRIPTION
I had set `skip_upload` to `false` when it should have been `true` 🙃