### PR TITLE
Added validation on datetime prefix message

### DIFF
--- a/stern/tail.go
+++ b/stern/tail.go
@@ -93,17 +93,13 @@ func (o TailOptions) UpdateTimezoneIfNeeded(message string) (string, error) {
 
 	idx := strings.IndexRune(message, ' ')
 	if idx == -1 {
-		return message, fmt.Errorf("missing timestamp")
+		return message, errors.New("missing timestamp")
 	}
 
 	datetime := message[:idx]
-	r, _ := regexp.Compile(`\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d(\.\d+([+-][0-2]\d:[0-5]\d|(Z)?))`)
-	if !r.MatchString(datetime) {
-		return message, fmt.Errorf("missing timestamp")
-	}
 	t, err := time.ParseInLocation(time.RFC3339Nano, datetime, time.UTC)
 	if err != nil {
-		return message, err
+		return message, errors.New("missing timestamp")
 	}
 
 	return t.In(o.Location).Format("2006-01-02T15:04:05.000000000Z07:00") + message[idx:], nil

--- a/stern/tail.go
+++ b/stern/tail.go
@@ -93,17 +93,17 @@ func (o TailOptions) UpdateTimezoneIfNeeded(message string) (string, error) {
 
 	idx := strings.IndexRune(message, ' ')
 	if idx == -1 {
-		return "", fmt.Errorf("missing timestamp")
+		return message, fmt.Errorf("missing timestamp")
 	}
 
 	datetime := message[:idx]
 	r, _ := regexp.Compile(`\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d(\.\d+([+-][0-2]\d:[0-5]\d|(Z)?))`)
 	if !r.MatchString(datetime) {
-		return "", fmt.Errorf("missing timestamp")
+		return message, fmt.Errorf("missing timestamp")
 	}
 	t, err := time.ParseInLocation(time.RFC3339Nano, datetime, time.UTC)
 	if err != nil {
-		return "", err
+		return message, err
 	}
 
 	return t.In(o.Location).Format("2006-01-02T15:04:05.000000000Z07:00") + message[idx:], nil
@@ -216,13 +216,13 @@ func (t *Tail) ConsumeRequest(ctx context.Context, request rest.ResponseWrapper)
 				continue
 			}
 
-			updatedMsg, err := t.Options.UpdateTimezoneIfNeeded(msg)
+			msg, err := t.Options.UpdateTimezoneIfNeeded(msg)
 			if err != nil {
 				t.Print(fmt.Sprintf("[%v] %s", err, msg))
 				continue
 			}
 
-			t.Print(updatedMsg)
+			t.Print(msg)
 		}
 
 		if err != nil {

--- a/stern/tail_test.go
+++ b/stern/tail_test.go
@@ -104,6 +104,16 @@ func TestUpdateTimezoneIfNeeded(t *testing.T) {
 			"",
 		},
 		{
+			"timestamp required on non timestamp message",
+			&TailOptions{
+				Timestamps: true,
+				Location:   location,
+			},
+			"Connection: keep-alive",
+			"",
+			"missing timestamp",
+		},
+		{
 			"not UTC",
 			&TailOptions{
 				Timestamps: true,

--- a/stern/tail_test.go
+++ b/stern/tail_test.go
@@ -110,7 +110,7 @@ func TestUpdateTimezoneIfNeeded(t *testing.T) {
 				Location:   location,
 			},
 			"Connection: keep-alive",
-			"",
+			"Connection: keep-alive",
 			"missing timestamp",
 		},
 		{


### PR DESCRIPTION
When `timestamp` flag is set to `true` but the cluster provide message without timestamp an error is shown instead of the actual message, so the user would not see what the server sent, this PR aims to not break the message but validate if there is a valid prefix date otherwise it will show the message prefixed with `[missing timestamp]`

It is a suggestion, just LMK if there is a better way or it just needs to be the way it is!

Fixes #161