### PR TITLE
added output modes to colorize json output

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ functions](https://golang.org/pkg/text/template/#hdr-Functions)):
 | `json`      | `object`              | Marshal the object and output it as a json text                 |
 | `color`     | `color.Color, string` | Wrap the text in color (.ContainerColor and .PodColor provided) |
 | `parseJSON` | `string`              | Parse string as JSON                                            |
-| `extjson`   | `string`              | Parse the object as json and output colorised json              |
-| `ppextjson` | `string`              | Parse the object as json and output pretty-print colorised json |
+| `extjson`   | `string`              | Parse the object as json and output colorized json              |
+| `ppextjson` | `string`              | Parse the object as json and output pretty-print colorized json |
 
 ## Examples:
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The `pod` query is a regular expression so you could provide `"web-\w"` to tail
  `--init-containers`         | `true`    | Include or exclude init containers.
  `--kubeconfig`              |           | Path to kubeconfig file to use. Default to KUBECONFIG variable then ~/.kube/config path.
  `--namespace`, `-n`         |           | Kubernetes namespace to use. Default to namespace configured in kubernetes context. To specify multiple namespaces, repeat this or set comma-separated value.
- `--output`, `-o`            | `default` | Specify predefined template. Currently support: [default, raw, json]
+ `--output`, `-o`            | `default` | Specify predefined template. Currently support: [default, raw, json, extjson, ppextjson]
  `--prompt`, `-p`            | `false`   | Toggle interactive prompt for selecting 'app.kubernetes.io/instance' label values.
  `--selector`, `-l`          |           | Selector (label query) to filter on. If present, default to ".*" for the pod-query.
  `--since`, `-s`             | `48h0m0s` | Return logs newer than a relative duration like 5s, 2m, or 3h.
@@ -126,7 +126,8 @@ functions](https://golang.org/pkg/text/template/#hdr-Functions)):
 | `json`      | `object`              | Marshal the object and output it as a json text                 |
 | `color`     | `color.Color, string` | Wrap the text in color (.ContainerColor and .PodColor provided) |
 | `parseJSON` | `string`              | Parse string as JSON                                            |
-
+| `extjson`   | `string`              | Parse the object as json and output colorised json              |
+| `ppextjson` | `string`              | Parse the object as json and output pretty-print colorised json |
 
 ## Examples:
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -229,13 +229,13 @@ func (o *options) sternConfig() (*stern.Config, error) {
 		case "json":
 			t = "{{json .}}"
 		case "extjson":
-			t = "\"pod\": \"{{color .PodColor .PodName}}\", \"container\": \"{{color .ContainerColor .ContainerName}}\", \"msg\": {{extjson .Message}}"
+			t = "\"pod\": \"{{color .PodColor .PodName}}\", \"container\": \"{{color .ContainerColor .ContainerName}}\", \"message\": {{extjson .Message}}"
 			if o.allNamespaces {
 				t = fmt.Sprintf("\"namespace\": \"{{color .PodColor .Namespace}}\", %s", t)
 			}
 			t = fmt.Sprintf("{%s}", t)
 		case "ppextjson":
-			t = "  \"pod\": \"{{color .PodColor .PodName}}\",\n  \"container\": \"{{color .ContainerColor .ContainerName}}\",\n  \"msg\": {{extjson .Message}}"
+			t = "  \"pod\": \"{{color .PodColor .PodName}}\",\n  \"container\": \"{{color .ContainerColor .ContainerName}}\",\n  \"message\": {{extjson .Message}}"
 			if o.allNamespaces {
 				t = fmt.Sprintf("  \"namespace\": \"{{color .PodColor .Namespace}}\",\n%s", t)
 			}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"strings"
 	"text/template"
 	"time"
 
@@ -227,6 +228,18 @@ func (o *options) sternConfig() (*stern.Config, error) {
 			t = "{{.Message}}"
 		case "json":
 			t = "{{json .}}"
+		case "extjson":
+			t = "\"pod\": \"{{color .PodColor .PodName}}\", \"container\": \"{{color .ContainerColor .ContainerName}}\", \"msg\": {{extjson .Message}}"
+			if o.allNamespaces {
+				t = fmt.Sprintf("\"namespace\": \"{{color .PodColor .Namespace}}\", %s", t)
+			}
+			t = fmt.Sprintf("{%s}", t)
+		case "ppextjson":
+			t = "  \"pod\": \"{{color .PodColor .PodName}}\",\n  \"container\": \"{{color .ContainerColor .ContainerName}}\",\n  \"msg\": {{extjson .Message}}"
+			if o.allNamespaces {
+				t = fmt.Sprintf("  \"namespace\": \"{{color .PodColor .Namespace}}\",\n%s", t)
+			}
+			t = fmt.Sprintf("{\n%s\n}", t)
 		}
 		t += "\n"
 	}
@@ -245,6 +258,16 @@ func (o *options) sternConfig() (*stern.Config, error) {
 				return obj, err
 			}
 			return obj, nil
+		},
+		"extjson": func(in interface{}) (string, error) {
+			if json.Valid([]byte(in.(string))) {
+				return strings.TrimSuffix(in.(string), "\n"), nil
+			}
+			b, err := json.Marshal(in)
+			if err != nil {
+				return "", err
+			}
+			return strings.TrimSuffix(string(b), "\n"), nil
 		},
 		"color": func(color color.Color, text string) string {
 			return color.SprintFunc()(text)
@@ -312,7 +335,7 @@ func (o *options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.kubeConfig, "kube-config", o.kubeConfig, "Path to kubeconfig file to use.")
 	_ = fs.MarkDeprecated("kube-config", "Use --kubeconfig instead.")
 	fs.StringSliceVarP(&o.namespaces, "namespace", "n", o.namespaces, "Kubernetes namespace to use. Default to namespace configured in kubernetes context. To specify multiple namespaces, repeat this or set comma-separated value.")
-	fs.StringVarP(&o.output, "output", "o", o.output, "Specify predefined template. Currently support: [default, raw, json]")
+	fs.StringVarP(&o.output, "output", "o", o.output, "Specify predefined template. Currently support: [default, raw, json, extjson, ppextjson]")
 	fs.BoolVarP(&o.prompt, "prompt", "p", o.prompt, "Toggle interactive prompt for selecting 'app.kubernetes.io/instance' label values.")
 	fs.StringVarP(&o.selector, "selector", "l", o.selector, "Selector (label query) to filter on. If present, default to \".*\" for the pod-query.")
 	fs.StringVar(&o.fieldSelector, "field-selector", o.fieldSelector, "Selector (field query) to filter on. If present, default to \".*\" for the pod-query.")

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -259,9 +259,9 @@ func (o *options) sternConfig() (*stern.Config, error) {
 			}
 			return obj, nil
 		},
-		"extjson": func(in interface{}) (string, error) {
-			if json.Valid([]byte(in.(string))) {
-				return strings.TrimSuffix(in.(string), "\n"), nil
+		"extjson": func(in string) (string, error) {
+			if json.Valid([]byte(in)) {
+				return strings.TrimSuffix(in, "\n"), nil
 			}
 			b, err := json.Marshal(in)
 			if err != nil {


### PR DESCRIPTION
This PR is about adding two new output modes to Stern:

- `extjson` is an extended json mode where the whole output is embeded in json and the namespace/pod/container values are color-coded as in the default mode.
- `ppextjson` is the same as the above with pretty-print, so each field is on its own line.

Both of those modes can be piped into `jq` if you want full pretty-print, but you'll lose the original color-coding.

I think those options are usefull when you're dealing with Json structured logs. It helps visializing the informations without being too intrusive. 
It's better than using the `raw` output or `raw | jq '.'` as pretty-printing the whole log line can quickly fill the console if you have lots of logs.

It's not a revolution but I guess it does not hurt to add this feature :)

ex:

```shell
./stern_cli nodepool-labeler-controller-manager --tail 2  --all-namespaces --output extjson -c manager

./stern_cli nodepool-labeler-controller-manager --tail 2  --all-namespaces --output extjson -c manager | jq '.'

./stern_cli nodepool-labeler-controller-manager --tail 2  --all-namespaces --output ppextjson -c manager
```
<img width="1432" alt="__stern_cli_nodepool-labeler-controller-manager_--tail_2_--all-namespaces___-_and_prune_nas____and_cli_go_—_stern" src="https://user-images.githubusercontent.com/1110398/192034751-13d76e9f-f573-4829-9fe1-f77124c3fe14.png">

<img width="1044" alt="__stern_cli_nodepool-labeler-controller-manager_--tail_2_--all-namespaces___-" src="https://user-images.githubusercontent.com/1110398/192034863-4d7c24f1-6c6f-40fe-b878-0af0c8e6471f.png">


<img width="1428" alt="__stern_cli_nodepool-labeler-controller-manager_--tail_2_--all-namespaces___-_and_prune_nas___" src="https://user-images.githubusercontent.com/1110398/192034923-3c7a0be9-95a4-4f7a-aa3a-b39a2ceaebe3.png">
