### PR TITLE
Add --resource flag to select pods by resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ The `pod` query is a regular expression so you could provide `"web-\w"` to tail
  `--no-follow`               | `false`   | Exit when all logs have been shown.
  `--output`, `-o`            | `default` | Specify predefined template. Currently support: [default, raw, json, extjson, ppextjson]
  `--prompt`, `-p`            | `false`   | Toggle interactive prompt for selecting 'app.kubernetes.io/instance' label values.
+ `--resource`                |           | Select pods by the specified resource in the form "&lt;resource&gt;/&lt;name&gt;". If present, default to ".*" for the pod-query.
  `--selector`, `-l`          |           | Selector (label query) to filter on. If present, default to ".*" for the pod-query.
  `--since`, `-s`             | `48h0m0s` | Return logs newer than a relative duration like 5s, 2m, or 3h.
  `--tail`                    | `-1`      | The number of lines from the end of the logs to show. Defaults to -1, showing all logs.
@@ -180,6 +181,11 @@ stern frontend --selector release=canary
 Tail the pods on `kind-control-plane` node across all namespaces
 ```
 stern --all-namespaces --field-selector spec.nodeName=kind-control-plane
+```
+
+Tail the pods created by `deployment/nginx`
+```
+stern --resource deployment/nginx
 ```
 
 Pipe the log message to jq:

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -56,7 +56,18 @@ func TestOptionsValidate(t *testing.T) {
 		{
 			"No required options",
 			NewOptions(streams),
-			"One of pod-query, --selector, --field-selector or --prompt is required",
+			"One of pod-query, --selector, --field-selector, --prompt or --resource is required",
+		},
+		{
+			"Specify both selector and resource",
+			func() *options {
+				o := NewOptions(streams)
+				o.selector = "app=nginx"
+				o.resource = "deployment/nginx"
+
+				return o
+			}(),
+			"--selector and --resource can not be set at the same time",
 		},
 		{
 			"Use prompt",

--- a/hack/update-readme/update-readme.go
+++ b/hack/update-readme/update-readme.go
@@ -96,6 +96,8 @@ func GenerateFlagsMarkdownTable() string {
 			defaultMaxlen = len(defaultText)
 		}
 
+		usage = strings.ReplaceAll(usage, "<", "&lt;")
+		usage = strings.ReplaceAll(usage, ">", "&gt;")
 		purposeText := fmt.Sprintf(" %s", usage)
 
 		allTexts = append(allTexts, []string{flagText, defaultText, purposeText})

--- a/stern/config.go
+++ b/stern/config.go
@@ -47,6 +47,7 @@ type Config struct {
 	TailLines             *int64
 	Template              *template.Template
 	Follow                bool
+	Resource              string
 
 	Out    io.Writer
 	ErrOut io.Writer

--- a/stern/stern.go
+++ b/stern/stern.go
@@ -230,6 +230,9 @@ func chooseSelector(ctx context.Context, client clientset.Interface, namespace, 
 	if err != nil {
 		return nil, err
 	}
+	if len(labelMap) == 0 {
+		return nil, fmt.Errorf("resource %s has no labels", resource)
+	}
 	return labels.SelectorFromSet(labelMap), nil
 }
 

--- a/stern/stern_test.go
+++ b/stern/stern_test.go
@@ -1,0 +1,194 @@
+package stern
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestRetrieveLabelsFromResource(t *testing.T) {
+	genMeta := func(name string) metav1.ObjectMeta {
+		return metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "ns1",
+		}
+	}
+	genPodTemplateSpec := func(name string) corev1.PodTemplateSpec {
+		return corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"app": name,
+				},
+			},
+		}
+	}
+	objs := []runtime.Object{
+		// core
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod1",
+				Namespace: "ns1",
+				Labels: map[string]string{
+					"app": "pod-label",
+				},
+			},
+		},
+		&corev1.ReplicationController{
+			ObjectMeta: genMeta("rc1"),
+			Spec: corev1.ReplicationControllerSpec{
+				Template: &corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"app": "rc-label",
+						},
+					},
+				},
+			},
+		},
+		// apps
+		&appsv1.Deployment{
+			ObjectMeta: genMeta("deploy1"),
+			Spec: appsv1.DeploymentSpec{
+				Template: genPodTemplateSpec("deploy-label"),
+			},
+		},
+		&appsv1.DaemonSet{
+			ObjectMeta: genMeta("ds1"),
+			Spec: appsv1.DaemonSetSpec{
+				Template: genPodTemplateSpec("ds-label"),
+			},
+		},
+		&appsv1.ReplicaSet{
+			ObjectMeta: genMeta("rs1"),
+			Spec: appsv1.ReplicaSetSpec{
+				Template: genPodTemplateSpec("rs-label"),
+			},
+		},
+		&appsv1.StatefulSet{
+			ObjectMeta: genMeta("sts1"),
+			Spec: appsv1.StatefulSetSpec{
+				Template: genPodTemplateSpec("sts-label"),
+			},
+		},
+		// batch
+		&batchv1.Job{
+			ObjectMeta: genMeta("job1"),
+			Spec: batchv1.JobSpec{
+				Template: genPodTemplateSpec("job-label"),
+			},
+		},
+		&batchv1.CronJob{
+			ObjectMeta: genMeta("cj1"),
+			Spec: batchv1.CronJobSpec{
+				JobTemplate: batchv1.JobTemplateSpec{
+					Spec: batchv1.JobSpec{
+						Template: genPodTemplateSpec("cj-label"),
+					},
+				},
+			},
+		},
+	}
+	client := fake.NewSimpleClientset(objs...)
+	tests := []struct {
+		desc      string
+		kinds     []string
+		name      string
+		label     string
+		wantError bool
+	}{
+		// core
+		{
+			desc:  "pods",
+			kinds: []string{"po", "pods", "pod"},
+			name:  "pod1",
+			label: "pod-label",
+		},
+		{
+			desc:  "replicationcontrollers",
+			kinds: []string{"rc", "replicationcontrollers", "replicationcontroller"},
+			name:  "rc1",
+			label: "rc-label",
+		},
+		// apps
+		{
+			desc:  "deployments",
+			kinds: []string{"deploy", "deployments", "deployment"},
+			name:  "deploy1",
+			label: "deploy-label",
+		},
+		{
+			desc:  "daemonsets",
+			kinds: []string{"ds", "daemonsets", "daemonset"},
+			name:  "ds1",
+			label: "ds-label",
+		},
+		{
+			desc:  "replicasets",
+			kinds: []string{"rs", "replicasets", "replicaset"},
+			name:  "rs1",
+			label: "rs-label",
+		},
+		{
+			desc:  "statefulsets",
+			kinds: []string{"sts", "statefulsets", "statefulset"},
+			name:  "sts1",
+			label: "sts-label",
+		},
+		// batch
+		{
+			desc:  "jobs",
+			kinds: []string{"job", "jobs"},
+			name:  "job1",
+			label: "job-label",
+		},
+		{
+			desc:  "cronjobs",
+			kinds: []string{"cj", "cronjobs", "cronjob"},
+			name:  "cj1",
+			label: "cj-label",
+		},
+		// invalid
+		{
+			desc:      "invalid",
+			kinds:     []string{"", "unknown"},
+			name:      "dummy",
+			wantError: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			for _, kind := range tt.kinds {
+				labels, err := retrieveLabelsFromResource(context.Background(), client, "ns1", kind, tt.name)
+				if tt.wantError {
+					if err == nil {
+						t.Errorf("expected error, but got no error")
+					}
+					return
+				}
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+					return
+				}
+				expectedLabels := map[string]string{"app": tt.label}
+				if !reflect.DeepEqual(expectedLabels, labels) {
+					t.Errorf("expected %v, but actual %v", expectedLabels, labels)
+				}
+
+				// test not found
+				_, err = retrieveLabelsFromResource(context.Background(), client, "ns1", kind, "not-found")
+				if !kerrors.IsNotFound(err) {
+					t.Errorf("expected not found, but actual %v", err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/stern/stern/issues/159

This PR adds `--resource` flag to select pods by the specified resource in the form "\<resource\>/\<name\>".

This will be useful when we want to distinct pods created by multiple deployments whose names are partly the same.

```
$ kubectl get deploy -n kube-system | grep cert-manager
cert-manager                             1/1     1            1           61d
cert-manager-cainjector                  1/1     1            1           61d
cert-manager-webhook                     1/1     1            1           61d

# It is not easy to select only pods created by `deployment/cert-manager` with pod-query.
$ stern -n kube-system --tail 0 cert-manager
+ cert-manager-webhook-d5568c87d-tcq6g › cert-manager
+ cert-manager-84bd74df78-zb28x › cert-manager
+ cert-manager-cainjector-6dd88998fb-wpb8h › cert-manager

# The resource flag allows users to select only pods created by `deployment/cert-manager`.
$ stern -n kube-system --tail 0 --resource deploy/cert-manager
+ cert-manager-84bd74df78-zb28x › cert-manager
```

It could be the first argument in the form "\<resource\>/\<regexp\>" instead of adding the flag as in https://github.com/stern/stern/issues/159#issuecomment-922684992. But the flag with the exact match is much simpler, so I implemented it as a flag.
