### PR TITLE
Fix indent in update-readme.go

### DIFF
--- a/hack/update-readme/update-readme.go
+++ b/hack/update-readme/update-readme.go
@@ -41,10 +41,11 @@ func main() {
 
 // GenerateFlagsMarkdownTable generates markdown table of flag list.
 // This function loads flag list and generates such as following text:
-//  flag            | default         | purpose
-// -----------------|-----------------|---------
-//  `--flag1`, `-f` |                 | This is flag1.
-//  `--flag2`       | `flag2-default` | This is flag2.
+//
+//	 flag            | default         | purpose
+//	-----------------|-----------------|---------
+//	 `--flag1`, `-f` |                 | This is flag1.
+//	 `--flag2`       | `flag2-default` | This is flag2.
 func GenerateFlagsMarkdownTable() string {
 	fs := pflag.NewFlagSet("", pflag.ExitOnError)
 	o := cmd.NewOptions(genericclioptions.NewTestIOStreamsDiscard())


### PR DESCRIPTION
This PR fixes the indent in update-readme.go as a code block.

Currently, `make fmt` will show the diff below.

```diff
diff --git a/hack/update-readme/update-readme.go b/hack/update-readme/update-readme.go
index 9526fdc..75e30a0 100644
--- a/hack/update-readme/update-readme.go
+++ b/hack/update-readme/update-readme.go
@@ -41,10 +41,13 @@ func main() {

 // GenerateFlagsMarkdownTable generates markdown table of flag list.
 // This function loads flag list and generates such as following text:
-//  flag            | default         | purpose
+//
+//     flag            | default         | purpose
+//
 // -----------------|-----------------|---------
-//  `--flag1`, `-f` |                 | This is flag1.
-//  `--flag2`       | `flag2-default` | This is flag2.
+//
+//     `--flag1`, `-f` |                 | This is flag1.
+//     `--flag2`       | `flag2-default` | This is flag2.
 func GenerateFlagsMarkdownTable() string {
        fs := pflag.NewFlagSet("", pflag.ExitOnError)
        o := cmd.NewOptions(genericclioptions.NewTestIOStreamsDiscard())
```