### PR TITLE
Support <resource>/<name> form as a query

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 Stern allows you to `tail` multiple pods on Kubernetes and multiple containers
 within the pod. Each result is color coded for quicker debugging.
 
-The query is a regular expression so the pod name can easily be filtered and
+The query is a regular expression or a Kubernetes resource in the form
+ `<resource>/<name>` so the pod name can easily be filtered and
 you don't need to specify the exact id (for instance omitting the deployment
 id). If a pod is deleted it gets removed from tail and if a new pod is added it
 automatically gets tailed.
@@ -55,8 +56,15 @@ kubectl krew install stern
 stern pod-query [flags]
 ```
 
-The `pod` query is a regular expression so you could provide `"web-\w"` to tail
-`web-backend` and `web-frontend` pods but not `web-123`.
+The `pod` query is a regular expression or a Kubernetes resource in the form `<resource>/<name>`.
+
+The query is a regular expression when it is not a Kubernetes resource,
+so you could provide `"web-\w"` to tail `web-backend` and `web-frontend` pods but not `web-123`.
+
+When the query is in the form `<resource>/<name>` (exact match), you can select all pods belonging
+to the specified Kubernetes resource, such as `deployment/nginx`.
+Supported Kubernetes resources are `pod`, `replicationcontroller`, `service`, `daemonset`, `deployment`,
+`replicaset`, `statefulset` and `job`.
 
 ### cli flags
 
@@ -180,6 +188,11 @@ stern frontend --selector release=canary
 Tail the pods on `kind-control-plane` node across all namespaces
 ```
 stern --all-namespaces --field-selector spec.nodeName=kind-control-plane
+```
+
+Tail the pods created by `deployment/nginx`
+```
+stern deployment/nginx
 ```
 
 Pipe the log message to jq:

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -59,6 +59,17 @@ func TestOptionsValidate(t *testing.T) {
 			"One of pod-query, --selector, --field-selector or --prompt is required",
 		},
 		{
+			"Specify both selector and resource",
+			func() *options {
+				o := NewOptions(streams)
+				o.selector = "app=nginx"
+				o.resource = "deployment/nginx"
+
+				return o
+			}(),
+			"--selector and the <resource>/<name> query can not be set at the same time",
+		},
+		{
 			"Use prompt",
 			func() *options {
 				o := NewOptions(streams)

--- a/stern/config.go
+++ b/stern/config.go
@@ -47,6 +47,7 @@ type Config struct {
 	TailLines             *int64
 	Template              *template.Template
 	Follow                bool
+	Resource              string
 
 	Out    io.Writer
 	ErrOut io.Writer

--- a/stern/resource_matcher.go
+++ b/stern/resource_matcher.go
@@ -1,0 +1,52 @@
+//   Copyright 2017 Wercker Holding BV
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package stern
+
+// ResourceMatcher is a matcher for Kubernetes resources
+type ResourceMatcher struct {
+	name    string   // the resource name in singular e.g. "deployment"
+	aliases []string // the aliases of the resource e.g. "deploy" and "deployments"
+}
+
+// Name returns the resource name in singular
+func (r *ResourceMatcher) Name() string {
+	return r.name
+}
+
+// AllNames returns the resource names including the aliases
+func (r *ResourceMatcher) AllNames() []string {
+	return append(r.aliases, r.name)
+}
+
+// Matches returns if name matches one of the resource names
+func (r *ResourceMatcher) Matches(name string) bool {
+	for _, n := range r.AllNames() {
+		if n == name {
+			return true
+		}
+	}
+	return false
+}
+
+var (
+	PodMatcher                   = ResourceMatcher{name: "pod", aliases: []string{"po", "pods"}}
+	ReplicationControllerMatcher = ResourceMatcher{name: "replicationcontroller", aliases: []string{"rc", "replicationcontrollers"}}
+	ServiceMatcher               = ResourceMatcher{name: "service", aliases: []string{"svc", "services"}}
+	DaemonSetMatcher             = ResourceMatcher{name: "daemonset", aliases: []string{"ds", "daemonsets"}}
+	DeploymentMatcher            = ResourceMatcher{name: "deployment", aliases: []string{"deploy", "deployments"}}
+	ReplicaSetMatcher            = ResourceMatcher{name: "replicaset", aliases: []string{"rs", "replicasets"}}
+	StatefulSetMatcher           = ResourceMatcher{name: "statefulset", aliases: []string{"sts", "statefulsets"}}
+	JobMatcher                   = ResourceMatcher{name: "job", aliases: []string{"jobs"}} // job does not have a short name
+)

--- a/stern/stern_test.go
+++ b/stern/stern_test.go
@@ -1,0 +1,202 @@
+package stern
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestRetrieveLabelsFromResource(t *testing.T) {
+	genMeta := func(name string) metav1.ObjectMeta {
+		return metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "ns1",
+		}
+	}
+	genPodTemplateSpec := func(name string) corev1.PodTemplateSpec {
+		return corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"app": name,
+				},
+			},
+		}
+	}
+	objs := []runtime.Object{
+		// core
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod1",
+				Namespace: "ns1",
+				Labels: map[string]string{
+					"app": "pod-label",
+				},
+			},
+		},
+		&corev1.ReplicationController{
+			ObjectMeta: genMeta("rc1"),
+			Spec: corev1.ReplicationControllerSpec{
+				Template: &corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"app": "rc-label",
+						},
+					},
+				},
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: genMeta("svc1"),
+			Spec: corev1.ServiceSpec{
+				Selector: map[string]string{
+					"app": "svc-label",
+				},
+			},
+		},
+		// apps
+		&appsv1.DaemonSet{
+			ObjectMeta: genMeta("ds1"),
+			Spec: appsv1.DaemonSetSpec{
+				Template: genPodTemplateSpec("ds-label"),
+			},
+		},
+		&appsv1.Deployment{
+			ObjectMeta: genMeta("deploy1"),
+			Spec: appsv1.DeploymentSpec{
+				Template: genPodTemplateSpec("deploy-label"),
+			},
+		},
+		&appsv1.ReplicaSet{
+			ObjectMeta: genMeta("rs1"),
+			Spec: appsv1.ReplicaSetSpec{
+				Template: genPodTemplateSpec("rs-label"),
+			},
+		},
+		&appsv1.StatefulSet{
+			ObjectMeta: genMeta("sts1"),
+			Spec: appsv1.StatefulSetSpec{
+				Template: genPodTemplateSpec("sts-label"),
+			},
+		},
+		// batch
+		&batchv1.Job{
+			ObjectMeta: genMeta("job1"),
+			Spec: batchv1.JobSpec{
+				Template: genPodTemplateSpec("job-label"),
+			},
+		},
+		&batchv1.CronJob{
+			ObjectMeta: genMeta("cj1"),
+			Spec: batchv1.CronJobSpec{
+				JobTemplate: batchv1.JobTemplateSpec{
+					Spec: batchv1.JobSpec{
+						Template: genPodTemplateSpec("cj-label"),
+					},
+				},
+			},
+		},
+	}
+	client := fake.NewSimpleClientset(objs...)
+	tests := []struct {
+		desc      string
+		kinds     []string
+		name      string
+		label     string
+		wantError bool
+	}{
+		// core
+		{
+			desc:  "pods",
+			kinds: []string{"po", "pods", "pod"},
+			name:  "pod1",
+			label: "pod-label",
+		},
+		{
+			desc:  "replicationcontrollers",
+			kinds: []string{"rc", "replicationcontrollers", "replicationcontroller"},
+			name:  "rc1",
+			label: "rc-label",
+		},
+		{
+			desc:  "services",
+			kinds: []string{"svc", "services", "service"},
+			name:  "svc1",
+			label: "svc-label",
+		},
+		// apps
+		{
+			desc:  "daemonsets",
+			kinds: []string{"ds", "daemonsets", "daemonset"},
+			name:  "ds1",
+			label: "ds-label",
+		},
+		{
+			desc:  "deployments",
+			kinds: []string{"deploy", "deployments", "deployment"},
+			name:  "deploy1",
+			label: "deploy-label",
+		},
+		{
+			desc:  "replicasets",
+			kinds: []string{"rs", "replicasets", "replicaset"},
+			name:  "rs1",
+			label: "rs-label",
+		},
+		{
+			desc:  "statefulsets",
+			kinds: []string{"sts", "statefulsets", "statefulset"},
+			name:  "sts1",
+			label: "sts-label",
+		},
+		// batch
+		{
+			desc:  "jobs",
+			kinds: []string{"job", "jobs"},
+			name:  "job1",
+			label: "job-label",
+		},
+		// invalid
+		{
+			desc:      "invalid",
+			kinds:     []string{"", "unknown"},
+			name:      "dummy",
+			wantError: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			for _, kind := range tt.kinds {
+				labels, err := retrieveLabelsFromResource(context.Background(), client, "ns1", kind, tt.name)
+				if tt.wantError {
+					if err == nil {
+						t.Errorf("expected error, but got no error")
+					}
+					return
+				}
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+					return
+				}
+				expectedLabels := map[string]string{"app": tt.label}
+				if !reflect.DeepEqual(expectedLabels, labels) {
+					t.Errorf("expected %v, but actual %v", expectedLabels, labels)
+				}
+
+				// test not found
+				_, err = retrieveLabelsFromResource(context.Background(), client, "ns1", kind, "not-found")
+				if !kerrors.IsNotFound(err) {
+					t.Errorf("expected not found, but actual %v", err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/stern/stern/issues/159

This PR supports a Kubernetes resource as a query in the form `<resource>/<name>`. As discussed in https://github.com/stern/stern/pull/206, this PR supports it as a query rather than a flag.

This feature will be useful when we want to distinguish pods created by multiple deployments whose names are partly the same.

```
$ kubectl get deploy -n kube-system | grep cert-manager
cert-manager              1/1     1            1           63d
cert-manager-cainjector   1/1     1            1           63d
cert-manager-webhook      1/1     1            1           63d

# It is not easy to select only pods created by `deployment/cert-manager` with a regular expression
$ stern -n kube-system --tail 0 cert-manager
+ cert-manager-webhook-6c587d5b6f-x26dr › cert-manager
+ cert-manager-7ff5799cff-7gjv5 › cert-manager
+ cert-manager-cainjector-6b4cf6bdf9-rxpcn › cert-manager

# The <resource>/<name> form allows users to select only pods created by `deployment/cert-manager`.
$ stern -n kube-system --tail 0 deployment/cert-manager
+ cert-manager-7ff5799cff-7gjv5 › cert-manager
```

Supported Kubernetes resources are the same as `kubectl logs`, which are `pod`, `replicationcontroller`, `service`, `daemonset`, `deployment`, `replicaset`, `statefulset` and `job`.

I will implement a dynamic completion for this feature after this PR is merged.