### PR TITLE
Fix bug where container-state is ignored when no-follow specified

### DIFF
--- a/stern/list.go
+++ b/stern/list.go
@@ -99,7 +99,9 @@ func ListTargets(ctx context.Context, i corev1client.PodInterface, labelSelector
 	var targets []*Target
 	for i := range list.Items {
 		filter.visit(&list.Items[i], func(t *Target, containerStateMatched bool) {
-			targets = append(targets, t)
+			if containerStateMatched {
+				targets = append(targets, t)
+			}
 		})
 	}
 	return targets, nil


### PR DESCRIPTION
This PR fixes a bug where `--container-state` is ignored when `--no-follow` is specified.