### PR TITLE
Add completion for flags with pre-defined choices

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,8 +234,8 @@ stern -p
 Stern supports command-line auto completion for bash, zsh or fish. `stern
 --completion=(bash|zsh|fish)` outputs the shell completion code which work by being
 evaluated in `.bashrc`, etc for the specified shell. In addition, Stern
-supports dynamic completion for `--namespace`, `--context` and a resource query
-in the form `<resource>/<name>`.
+supports dynamic completion for `--namespace`, `--context`, a resource query
+in the form `<resource>/<name>`, and flags with pre-defined choices.
 
 If you use bash, stern bash completion code depends on the
 [bash-completion](https://github.com/scop/bash-completion). On the macOS, you

--- a/cmd/flag_completion.go
+++ b/cmd/flag_completion.go
@@ -29,6 +29,13 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 )
 
+var flagChoices = map[string][]string{
+	"color":           []string{"always", "never", "auto"},
+	"completion":      []string{"bash", "zsh", "fish"},
+	"container-state": []string{stern.RUNNING, stern.WAITING, stern.TERMINATED},
+	"output":          []string{"default", "raw", "json", "extjson", "ppextjson"},
+}
+
 func runCompletion(shell string, cmd *cobra.Command, out io.Writer) error {
 	var err error
 
@@ -70,6 +77,14 @@ func registerCompletionFuncForFlags(cmd *cobra.Command, o *options) error {
 
 	if err := cmd.RegisterFlagCompletionFunc("context", contextCompletionFunc(o)); err != nil {
 		return err
+	}
+
+	// flags with pre-defined choices
+	for flag, choices := range flagChoices {
+		if err := cmd.RegisterFlagCompletionFunc(flag,
+			cobra.FixedCompletions(choices, cobra.ShellCompDirectiveNoFileComp)); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This PR adds completion for flags with pre-defined choices. These flags are currently `--color`, `--completion`, `--container-state`, and `--output`. 
