### PR TITLE
Add --verbosity flag to set log level verbosity

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Supported Kubernetes resources are `pod`, `replicationcontroller`, `service`, `d
  `--template`                |           | Template to use for log lines, leave empty to use --output flag.
  `--timestamps`, `-t`        | `false`   | Print timestamps.
  `--timezone`                | `Local`   | Set timestamps to specific timezone.
+ `--verbosity`               | `0`       | Number of the log level verbosity
  `--version`, `-v`           | `false`   | Print the version and exit.
 <!-- auto generated cli flags end --->
 
@@ -137,6 +138,13 @@ functions](https://golang.org/pkg/text/template/#hdr-Functions)):
 | `parseJSON` | `string`              | Parse string as JSON                                            |
 | `extjson`   | `string`              | Parse the object as json and output colorized json              |
 | `ppextjson` | `string`              | Parse the object as json and output pretty-print colorized json |
+
+### Log level verbosity
+
+You can configure the log level verbosity by the `--verbose` flag.
+It is useful when you want to know how stern interacts with a Kubernetes API server in troubleshooting.
+
+Increasing the verbosity increases the number of logs. `--verbose 6` would be a good starting point.
 
 ## Examples:
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	k8s.io/apimachinery v0.26.0
 	k8s.io/cli-runtime v0.26.0
 	k8s.io/client-go v0.26.0
+	k8s.io/klog/v2 v2.80.1
 )
 
 require (
@@ -61,7 +62,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230109183929-3758b55a6596 // indirect
 	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect


### PR DESCRIPTION
Fixes https://github.com/stern/stern/issues/139

This PR adds the `--verbosity` flag to set the log level verbosity of client-go. This feature will be useful when we want to know how stern interacts with a Kubernetes API server in troubleshooting.

The default flag `-v` of klog conflicted with the short name of `--version` of stern, so I added it as a new flag.

It works as follows.

```
$ stern --verbosity 6 --tail 0 deployment/nginx
I0126 09:55:55.675598   61274 loader.go:373] Config loaded from file:  /Users/tkusumi/.kube/config
I0126 09:55:55.677173   61274 cert_rotation.go:137] Starting client certificate rotation controller
I0126 09:55:55.704852   61274 round_trippers.go:553] GET https://127.0.0.1:54663/apis/apps/v1/namespaces/default/deployments/nginx 200 OK in 27 milliseconds
I0126 09:55:55.706159   61274 retrywatcher.go:247] Starting RetryWatcher.
I0126 09:55:55.707653   61274 round_trippers.go:553] GET https://127.0.0.1:54663/api/v1/namespaces/default/pods?labelSelector=app%3Dnginx&watch=true 200 OK in 1 milliseconds
+ nginx-76d6c9b8c-nlqs9 › nginx
+ nginx-76d6c9b8c-bqqdm › nginx
+ nginx-76d6c9b8c-mg7x7 › nginx
I0126 09:55:55.719894   61274 round_trippers.go:553] GET https://127.0.0.1:54663/api/v1/namespaces/default/pods/nginx-76d6c9b8c-bqqdm/log?container=nginx&follow=true&sinceSeconds=172800&tailLines=0 200 OK in 11 milliseconds
I0126 09:55:55.720401   61274 round_trippers.go:553] GET https://127.0.0.1:54663/api/v1/namespaces/default/pods/nginx-76d6c9b8c-nlqs9/log?container=nginx&follow=true&sinceSeconds=172800&tailLines=0 200 OK in 11 milliseconds
I0126 09:55:55.721048   61274 round_trippers.go:553] GET https://127.0.0.1:54663/api/v1/namespaces/default/pods/nginx-76d6c9b8c-mg7x7/log?container=nginx&follow=true&sinceSeconds=172800&tailLines=0 200 OK in 12 milliseconds
```
