### PR TITLE
Add --only-log-lines flag that prints only log lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Supported Kubernetes resources are `pod`, `replicationcontroller`, `service`, `d
  `--kubeconfig`              |           | Path to kubeconfig file to use. Default to KUBECONFIG variable then ~/.kube/config path.
  `--namespace`, `-n`         |           | Kubernetes namespace to use. Default to namespace configured in kubernetes context. To specify multiple namespaces, repeat this or set comma-separated value.
  `--no-follow`               | `false`   | Exit when all logs have been shown.
+ `--only-log-lines`          | `false`   | Print only log lines
  `--output`, `-o`            | `default` | Specify predefined template. Currently support: [default, raw, json, extjson, ppextjson]
  `--prompt`, `-p`            | `false`   | Toggle interactive prompt for selecting 'app.kubernetes.io/instance' label values.
  `--selector`, `-l`          |           | Selector (label query) to filter on. If present, default to ".*" for the pod-query.
@@ -235,6 +236,12 @@ Trigger the interactive prompt to select an 'app.kubernetes.io/instance' label v
 
 ```
 stern -p
+```
+
+Output log lines only:
+
+```
+stern . --only-log-lines
 ```
 
 ## Completion

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -68,6 +68,7 @@ type options struct {
 	noFollow            bool
 	resource            string
 	verbosity           int
+	onlyLogLines        bool
 }
 
 func NewOptions(streams genericclioptions.IOStreams) *options {
@@ -331,6 +332,7 @@ func (o *options) sternConfig() (*stern.Config, error) {
 		Template:              template,
 		Follow:                !o.noFollow,
 		Resource:              o.resource,
+		OnlyLogLines:          o.onlyLogLines,
 
 		Out:    o.Out,
 		ErrOut: o.ErrOut,
@@ -378,6 +380,7 @@ func (o *options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.template, "template", o.template, "Template to use for log lines, leave empty to use --output flag.")
 	fs.BoolVarP(&o.timestamps, "timestamps", "t", o.timestamps, "Print timestamps.")
 	fs.StringVar(&o.timezone, "timezone", o.timezone, "Set timestamps to specific timezone.")
+	fs.BoolVar(&o.onlyLogLines, "only-log-lines", o.onlyLogLines, "Print only log lines")
 	fs.IntVar(&o.verbosity, "verbosity", o.verbosity, "Number of the log level verbosity")
 	fs.BoolVarP(&o.version, "version", "v", o.version, "Print the version and exit.")
 }

--- a/stern/config.go
+++ b/stern/config.go
@@ -48,6 +48,7 @@ type Config struct {
 	Template              *template.Template
 	Follow                bool
 	Resource              string
+	OnlyLogLines          bool
 
 	Out    io.Writer
 	ErrOut io.Writer

--- a/stern/stern.go
+++ b/stern/stern.go
@@ -121,6 +121,7 @@ func Run(ctx context.Context, config *Config) error {
 			Namespace:    config.AllNamespaces || len(namespaces) > 1,
 			TailLines:    config.TailLines,
 			Follow:       config.Follow,
+			OnlyLogLines: config.OnlyLogLines,
 		})
 	}
 


### PR DESCRIPTION
This PR adds a new flag `--only-log-lines` that prints only log lines.

```
$ stern . --tail=1
+ nginx-cfbcb7b98-29wn7 › nginx
+ nginx-cfbcb7b98-96xsv › nginx
nginx-cfbcb7b98-96xsv nginx 2023/01/27 13:20:48 [notice] 1#1: start worker process 46
nginx-cfbcb7b98-29wn7 nginx 2023/01/27 13:20:45 [notice] 1#1: start worker process 46
^C

$ stern . --tail=1 --only-log-lines
nginx-cfbcb7b98-96xsv nginx 2023/01/27 13:20:48 [notice] 1#1: start worker process 46
nginx-cfbcb7b98-29wn7 nginx 2023/01/27 13:20:45 [notice] 1#1: start worker process 46
^C
```

/ref https://github.com/stern/stern/discussions/202