### PR TITLE
Allow to specify --exclude-pod/container multiple times

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ Supported Kubernetes resources are `pod`, `replicationcontroller`, `service`, `d
  `--context`                 |           | Kubernetes context to use. Default to current context configured in kubeconfig.
  `--ephemeral-containers`    | `true`    | Include or exclude ephemeral containers.
  `--exclude`, `-e`           | `[]`      | Log lines to exclude. (regular expression)
- `--exclude-container`, `-E` |           | Container name to exclude when multiple containers in pod. (regular expression)
- `--exclude-pod`             |           | Pod name to exclude. (regular expression)
+ `--exclude-container`, `-E` | `[]`      | Container name to exclude when multiple containers in pod. (regular expression)
+ `--exclude-pod`             | `[]`      | Pod name to exclude. (regular expression)
  `--field-selector`          |           | Selector (field query) to filter on. If present, default to ".*" for the pod-query.
  `--include`, `-i`           | `[]`      | Log lines to include. (regular expression)
  `--init-containers`         | `true`    | Include or exclude init containers.

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -40,9 +40,9 @@ import (
 type options struct {
 	genericclioptions.IOStreams
 
-	excludePod          string
+	excludePod          []string
 	container           string
-	excludeContainer    string
+	excludeContainer    []string
 	containerStates     []string
 	timestamps          bool
 	timezone            string
@@ -141,12 +141,14 @@ func (o *options) sternConfig() (*stern.Config, error) {
 		return nil, errors.Wrap(err, "failed to compile regular expression from query")
 	}
 
-	var excludePod *regexp.Regexp
-	if o.excludePod != "" {
-		excludePod, err = regexp.Compile(o.excludePod)
+	var excludePod []*regexp.Regexp
+	for _, s := range o.excludePod {
+		re, err := regexp.Compile(s)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to compile regular exression for excluded pod query")
+			return nil, errors.Wrap(err, "failed to compile regular expression for excluded pod query")
 		}
+
+		excludePod = append(excludePod, re)
 	}
 
 	container, err := regexp.Compile(o.container)
@@ -154,12 +156,14 @@ func (o *options) sternConfig() (*stern.Config, error) {
 		return nil, errors.Wrap(err, "failed to compile regular expression for container query")
 	}
 
-	var excludeContainer *regexp.Regexp
-	if o.excludeContainer != "" {
-		excludeContainer, err = regexp.Compile(o.excludeContainer)
+	var excludeContainer []*regexp.Regexp
+	for _, s := range o.excludeContainer {
+		re, err := regexp.Compile(s)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to compile regular expression for exclude container query")
+			return nil, errors.Wrap(err, "failed to compile regular expression for excluded container query")
 		}
+
+		excludeContainer = append(excludeContainer, re)
 	}
 
 	var exclude []*regexp.Regexp
@@ -359,8 +363,8 @@ func (o *options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringSliceVar(&o.containerStates, "container-state", o.containerStates, "Tail containers with state in running, waiting or terminated. To specify multiple states, repeat this or set comma-separated value.")
 	fs.StringVar(&o.context, "context", o.context, "Kubernetes context to use. Default to current context configured in kubeconfig.")
 	fs.StringArrayVarP(&o.exclude, "exclude", "e", o.exclude, "Log lines to exclude. (regular expression)")
-	fs.StringVarP(&o.excludeContainer, "exclude-container", "E", o.excludeContainer, "Container name to exclude when multiple containers in pod. (regular expression)")
-	fs.StringVar(&o.excludePod, "exclude-pod", o.excludePod, "Pod name to exclude. (regular expression)")
+	fs.StringArrayVarP(&o.excludeContainer, "exclude-container", "E", o.excludeContainer, "Container name to exclude when multiple containers in pod. (regular expression)")
+	fs.StringArrayVar(&o.excludePod, "exclude-pod", o.excludePod, "Pod name to exclude. (regular expression)")
 	fs.BoolVar(&o.noFollow, "no-follow", o.noFollow, "Exit when all logs have been shown.")
 	fs.StringArrayVarP(&o.include, "include", "i", o.include, "Log lines to include. (regular expression)")
 	fs.BoolVar(&o.initContainers, "init-containers", o.initContainers, "Include or exclude init containers.")

--- a/stern/config.go
+++ b/stern/config.go
@@ -30,11 +30,11 @@ type Config struct {
 	ContextName           string
 	Namespaces            []string
 	PodQuery              *regexp.Regexp
-	ExcludePodQuery       *regexp.Regexp
+	ExcludePodQuery       []*regexp.Regexp
 	Timestamps            bool
 	Location              *time.Location
 	ContainerQuery        *regexp.Regexp
-	ExcludeContainerQuery *regexp.Regexp
+	ExcludeContainerQuery []*regexp.Regexp
 	ContainerStates       []ContainerState
 	Exclude               []*regexp.Regexp
 	Include               []*regexp.Regexp

--- a/stern/target_test.go
+++ b/stern/target_test.go
@@ -14,43 +14,50 @@ func TestTargetFilter(t *testing.T) {
 	terminated := corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{}}
 	waiting := corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{}}
 
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "ns1",
-			Name:      "pod1",
-		},
-		Spec: corev1.PodSpec{
-			NodeName: "node1",
-		},
-		Status: corev1.PodStatus{
-			ContainerStatuses: []corev1.ContainerStatus{
-				{Name: "container1-running", State: running},
-				{Name: "container2-terminated", State: terminated},
-				{Name: "container3-waiting", State: waiting},
+	createPod := func(node, pod string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns1",
+				Name:      pod,
 			},
-			InitContainerStatuses: []corev1.ContainerStatus{
-				{Name: "init-container1-running", State: running},
-				{Name: "init-container2-terminated", State: terminated},
-				{Name: "init-container3-waiting", State: waiting},
+			Spec: corev1.PodSpec{
+				NodeName: node,
 			},
-			EphemeralContainerStatuses: []corev1.ContainerStatus{
-				{Name: "ephemeral-container1-running", State: running},
-				{Name: "ephemeral-container2-terminated", State: terminated},
-				{Name: "ephemeral-container3-waiting", State: waiting},
+			Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					{Name: "container1-running", State: running},
+					{Name: "container2-terminated", State: terminated},
+					{Name: "container3-waiting", State: waiting},
+				},
+				InitContainerStatuses: []corev1.ContainerStatus{
+					{Name: "init-container1-running", State: running},
+					{Name: "init-container2-terminated", State: terminated},
+					{Name: "init-container3-waiting", State: waiting},
+				},
+				EphemeralContainerStatuses: []corev1.ContainerStatus{
+					{Name: "ephemeral-container1-running", State: running},
+					{Name: "ephemeral-container2-terminated", State: terminated},
+					{Name: "ephemeral-container3-waiting", State: waiting},
+				},
 			},
-		},
+		}
+	}
+
+	pods := []*corev1.Pod{
+		createPod("node1", "pod1"),
+		createPod("node2", "pod2"),
 	}
 
 	type targetMatch struct {
 		target                Target
 		containerStateMatched bool
 	}
-	genTargetMatch := func(container string, matched bool) targetMatch {
+	genTargetMatch := func(node, pod, container string, matched bool) targetMatch {
 		return targetMatch{
 			target: Target{
-				Node:      "node1",
 				Namespace: "ns1",
-				Pod:       "pod1",
+				Node:      node,
+				Pod:       pod,
 				Container: container,
 			},
 			containerStateMatched: matched,
@@ -74,15 +81,24 @@ func TestTargetFilter(t *testing.T) {
 				containerStates:        []ContainerState{RUNNING, TERMINATED, WAITING},
 			},
 			expected: []targetMatch{
-				genTargetMatch("container1-running", true),
-				genTargetMatch("container2-terminated", true),
-				genTargetMatch("container3-waiting", true),
-				genTargetMatch("init-container1-running", true),
-				genTargetMatch("init-container2-terminated", true),
-				genTargetMatch("init-container3-waiting", true),
-				genTargetMatch("ephemeral-container1-running", true),
-				genTargetMatch("ephemeral-container2-terminated", true),
-				genTargetMatch("ephemeral-container3-waiting", true),
+				genTargetMatch("node1", "pod1", "container1-running", true),
+				genTargetMatch("node1", "pod1", "container2-terminated", true),
+				genTargetMatch("node1", "pod1", "container3-waiting", true),
+				genTargetMatch("node1", "pod1", "init-container1-running", true),
+				genTargetMatch("node1", "pod1", "init-container2-terminated", true),
+				genTargetMatch("node1", "pod1", "init-container3-waiting", true),
+				genTargetMatch("node1", "pod1", "ephemeral-container1-running", true),
+				genTargetMatch("node1", "pod1", "ephemeral-container2-terminated", true),
+				genTargetMatch("node1", "pod1", "ephemeral-container3-waiting", true),
+				genTargetMatch("node2", "pod2", "container1-running", true),
+				genTargetMatch("node2", "pod2", "container2-terminated", true),
+				genTargetMatch("node2", "pod2", "container3-waiting", true),
+				genTargetMatch("node2", "pod2", "init-container1-running", true),
+				genTargetMatch("node2", "pod2", "init-container2-terminated", true),
+				genTargetMatch("node2", "pod2", "init-container3-waiting", true),
+				genTargetMatch("node2", "pod2", "ephemeral-container1-running", true),
+				genTargetMatch("node2", "pod2", "ephemeral-container2-terminated", true),
+				genTargetMatch("node2", "pod2", "ephemeral-container3-waiting", true),
 			},
 		},
 		{
@@ -102,14 +118,50 @@ func TestTargetFilter(t *testing.T) {
 			name: "filter by excludePodFilter",
 			filter: targetFilter{
 				podFilter:              regexp.MustCompile(``),
-				excludePodFilter:       regexp.MustCompile(`pod1`),
+				excludePodFilter:       []*regexp.Regexp{regexp.MustCompile(`pod1`)},
 				containerFilter:        regexp.MustCompile(`.*`),
 				containerExcludeFilter: nil,
 				initContainers:         true,
 				ephemeralContainers:    true,
 				containerStates:        []ContainerState{RUNNING, TERMINATED, WAITING},
 			},
-			expected: []targetMatch{},
+			expected: []targetMatch{
+				genTargetMatch("node2", "pod2", "container1-running", true),
+				genTargetMatch("node2", "pod2", "container2-terminated", true),
+				genTargetMatch("node2", "pod2", "container3-waiting", true),
+				genTargetMatch("node2", "pod2", "init-container1-running", true),
+				genTargetMatch("node2", "pod2", "init-container2-terminated", true),
+				genTargetMatch("node2", "pod2", "init-container3-waiting", true),
+				genTargetMatch("node2", "pod2", "ephemeral-container1-running", true),
+				genTargetMatch("node2", "pod2", "ephemeral-container2-terminated", true),
+				genTargetMatch("node2", "pod2", "ephemeral-container3-waiting", true),
+			},
+		},
+		{
+			name: "filter by multiple excludePodFilter",
+			filter: targetFilter{
+				podFilter: regexp.MustCompile(``),
+				excludePodFilter: []*regexp.Regexp{
+					regexp.MustCompile(`not-matched`),
+					regexp.MustCompile(`pod2`),
+				},
+				containerFilter:        regexp.MustCompile(`.*`),
+				containerExcludeFilter: nil,
+				initContainers:         true,
+				ephemeralContainers:    true,
+				containerStates:        []ContainerState{RUNNING, TERMINATED, WAITING},
+			},
+			expected: []targetMatch{
+				genTargetMatch("node1", "pod1", "container1-running", true),
+				genTargetMatch("node1", "pod1", "container2-terminated", true),
+				genTargetMatch("node1", "pod1", "container3-waiting", true),
+				genTargetMatch("node1", "pod1", "init-container1-running", true),
+				genTargetMatch("node1", "pod1", "init-container2-terminated", true),
+				genTargetMatch("node1", "pod1", "init-container3-waiting", true),
+				genTargetMatch("node1", "pod1", "ephemeral-container1-running", true),
+				genTargetMatch("node1", "pod1", "ephemeral-container2-terminated", true),
+				genTargetMatch("node1", "pod1", "ephemeral-container3-waiting", true),
+			},
 		},
 		{
 			name: "filter by containerFilter",
@@ -123,9 +175,12 @@ func TestTargetFilter(t *testing.T) {
 				containerStates:        []ContainerState{RUNNING, TERMINATED, WAITING},
 			},
 			expected: []targetMatch{
-				genTargetMatch("container1-running", true),
-				genTargetMatch("init-container1-running", true),
-				genTargetMatch("ephemeral-container1-running", true),
+				genTargetMatch("node1", "pod1", "container1-running", true),
+				genTargetMatch("node1", "pod1", "init-container1-running", true),
+				genTargetMatch("node1", "pod1", "ephemeral-container1-running", true),
+				genTargetMatch("node2", "pod2", "container1-running", true),
+				genTargetMatch("node2", "pod2", "init-container1-running", true),
+				genTargetMatch("node2", "pod2", "ephemeral-container1-running", true),
 			},
 		},
 		{
@@ -134,18 +189,51 @@ func TestTargetFilter(t *testing.T) {
 				podFilter:              regexp.MustCompile(`.*`),
 				excludePodFilter:       nil,
 				containerFilter:        regexp.MustCompile(`.*`),
-				containerExcludeFilter: regexp.MustCompile(`.*container1.*`),
+				containerExcludeFilter: []*regexp.Regexp{regexp.MustCompile(`.*container1.*`)},
 				initContainers:         true,
 				ephemeralContainers:    true,
 				containerStates:        []ContainerState{RUNNING, TERMINATED, WAITING},
 			},
 			expected: []targetMatch{
-				genTargetMatch("container2-terminated", true),
-				genTargetMatch("container3-waiting", true),
-				genTargetMatch("init-container2-terminated", true),
-				genTargetMatch("init-container3-waiting", true),
-				genTargetMatch("ephemeral-container2-terminated", true),
-				genTargetMatch("ephemeral-container3-waiting", true),
+				genTargetMatch("node1", "pod1", "container2-terminated", true),
+				genTargetMatch("node1", "pod1", "container3-waiting", true),
+				genTargetMatch("node1", "pod1", "init-container2-terminated", true),
+				genTargetMatch("node1", "pod1", "init-container3-waiting", true),
+				genTargetMatch("node1", "pod1", "ephemeral-container2-terminated", true),
+				genTargetMatch("node1", "pod1", "ephemeral-container3-waiting", true),
+				genTargetMatch("node2", "pod2", "container2-terminated", true),
+				genTargetMatch("node2", "pod2", "container3-waiting", true),
+				genTargetMatch("node2", "pod2", "init-container2-terminated", true),
+				genTargetMatch("node2", "pod2", "init-container3-waiting", true),
+				genTargetMatch("node2", "pod2", "ephemeral-container2-terminated", true),
+				genTargetMatch("node2", "pod2", "ephemeral-container3-waiting", true),
+			},
+		},
+		{
+			name: "filter by multiple containerExcludeFilter",
+			filter: targetFilter{
+				podFilter:        regexp.MustCompile(`.*`),
+				excludePodFilter: nil,
+				containerFilter:  regexp.MustCompile(`.*`),
+				containerExcludeFilter: []*regexp.Regexp{
+					regexp.MustCompile(`.*container1.*`),
+					regexp.MustCompile(`init-container2.*`),
+				},
+				initContainers:      true,
+				ephemeralContainers: true,
+				containerStates:     []ContainerState{RUNNING, TERMINATED, WAITING},
+			},
+			expected: []targetMatch{
+				genTargetMatch("node1", "pod1", "container2-terminated", true),
+				genTargetMatch("node1", "pod1", "container3-waiting", true),
+				genTargetMatch("node1", "pod1", "init-container3-waiting", true),
+				genTargetMatch("node1", "pod1", "ephemeral-container2-terminated", true),
+				genTargetMatch("node1", "pod1", "ephemeral-container3-waiting", true),
+				genTargetMatch("node2", "pod2", "container2-terminated", true),
+				genTargetMatch("node2", "pod2", "container3-waiting", true),
+				genTargetMatch("node2", "pod2", "init-container3-waiting", true),
+				genTargetMatch("node2", "pod2", "ephemeral-container2-terminated", true),
+				genTargetMatch("node2", "pod2", "ephemeral-container3-waiting", true),
 			},
 		},
 		{
@@ -160,12 +248,18 @@ func TestTargetFilter(t *testing.T) {
 				containerStates:        []ContainerState{RUNNING, TERMINATED, WAITING},
 			},
 			expected: []targetMatch{
-				genTargetMatch("container1-running", true),
-				genTargetMatch("container2-terminated", true),
-				genTargetMatch("container3-waiting", true),
-				genTargetMatch("ephemeral-container1-running", true),
-				genTargetMatch("ephemeral-container2-terminated", true),
-				genTargetMatch("ephemeral-container3-waiting", true),
+				genTargetMatch("node1", "pod1", "container1-running", true),
+				genTargetMatch("node1", "pod1", "container2-terminated", true),
+				genTargetMatch("node1", "pod1", "container3-waiting", true),
+				genTargetMatch("node1", "pod1", "ephemeral-container1-running", true),
+				genTargetMatch("node1", "pod1", "ephemeral-container2-terminated", true),
+				genTargetMatch("node1", "pod1", "ephemeral-container3-waiting", true),
+				genTargetMatch("node2", "pod2", "container1-running", true),
+				genTargetMatch("node2", "pod2", "container2-terminated", true),
+				genTargetMatch("node2", "pod2", "container3-waiting", true),
+				genTargetMatch("node2", "pod2", "ephemeral-container1-running", true),
+				genTargetMatch("node2", "pod2", "ephemeral-container2-terminated", true),
+				genTargetMatch("node2", "pod2", "ephemeral-container3-waiting", true),
 			},
 		},
 		{
@@ -180,12 +274,18 @@ func TestTargetFilter(t *testing.T) {
 				containerStates:        []ContainerState{RUNNING, TERMINATED, WAITING},
 			},
 			expected: []targetMatch{
-				genTargetMatch("container1-running", true),
-				genTargetMatch("container2-terminated", true),
-				genTargetMatch("container3-waiting", true),
-				genTargetMatch("init-container1-running", true),
-				genTargetMatch("init-container2-terminated", true),
-				genTargetMatch("init-container3-waiting", true),
+				genTargetMatch("node1", "pod1", "container1-running", true),
+				genTargetMatch("node1", "pod1", "container2-terminated", true),
+				genTargetMatch("node1", "pod1", "container3-waiting", true),
+				genTargetMatch("node1", "pod1", "init-container1-running", true),
+				genTargetMatch("node1", "pod1", "init-container2-terminated", true),
+				genTargetMatch("node1", "pod1", "init-container3-waiting", true),
+				genTargetMatch("node2", "pod2", "container1-running", true),
+				genTargetMatch("node2", "pod2", "container2-terminated", true),
+				genTargetMatch("node2", "pod2", "container3-waiting", true),
+				genTargetMatch("node2", "pod2", "init-container1-running", true),
+				genTargetMatch("node2", "pod2", "init-container2-terminated", true),
+				genTargetMatch("node2", "pod2", "init-container3-waiting", true),
 			},
 		},
 		{
@@ -200,15 +300,24 @@ func TestTargetFilter(t *testing.T) {
 				containerStates:        []ContainerState{RUNNING},
 			},
 			expected: []targetMatch{
-				genTargetMatch("container1-running", true),
-				genTargetMatch("container2-terminated", false),
-				genTargetMatch("container3-waiting", false),
-				genTargetMatch("init-container1-running", true),
-				genTargetMatch("init-container2-terminated", false),
-				genTargetMatch("init-container3-waiting", false),
-				genTargetMatch("ephemeral-container1-running", true),
-				genTargetMatch("ephemeral-container2-terminated", false),
-				genTargetMatch("ephemeral-container3-waiting", false),
+				genTargetMatch("node1", "pod1", "container1-running", true),
+				genTargetMatch("node1", "pod1", "container2-terminated", false),
+				genTargetMatch("node1", "pod1", "container3-waiting", false),
+				genTargetMatch("node1", "pod1", "init-container1-running", true),
+				genTargetMatch("node1", "pod1", "init-container2-terminated", false),
+				genTargetMatch("node1", "pod1", "init-container3-waiting", false),
+				genTargetMatch("node1", "pod1", "ephemeral-container1-running", true),
+				genTargetMatch("node1", "pod1", "ephemeral-container2-terminated", false),
+				genTargetMatch("node1", "pod1", "ephemeral-container3-waiting", false),
+				genTargetMatch("node2", "pod2", "container1-running", true),
+				genTargetMatch("node2", "pod2", "container2-terminated", false),
+				genTargetMatch("node2", "pod2", "container3-waiting", false),
+				genTargetMatch("node2", "pod2", "init-container1-running", true),
+				genTargetMatch("node2", "pod2", "init-container2-terminated", false),
+				genTargetMatch("node2", "pod2", "init-container3-waiting", false),
+				genTargetMatch("node2", "pod2", "ephemeral-container1-running", true),
+				genTargetMatch("node2", "pod2", "ephemeral-container2-terminated", false),
+				genTargetMatch("node2", "pod2", "ephemeral-container3-waiting", false),
 			},
 		},
 	}
@@ -216,9 +325,12 @@ func TestTargetFilter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			actual := []targetMatch{}
-			tt.filter.visit(pod, func(target *Target, containerStateMatched bool) {
-				actual = append(actual, targetMatch{target: *target, containerStateMatched: containerStateMatched})
-			})
+			for _, pod := range pods {
+				tt.filter.visit(pod, func(target *Target, containerStateMatched bool) {
+					actual = append(actual, targetMatch{target: *target, containerStateMatched: containerStateMatched})
+				})
+			}
+
 			if !reflect.DeepEqual(tt.expected, actual) {
 				t.Errorf("expected %v, but actual %v", tt.expected, actual)
 			}


### PR DESCRIPTION
This PR allows users to specify `--exclude-pod/container` multiple times.

```
$ stern . --exclude-pod pod1 --exclude-pod pod2

$ stern . --exclude-container container1 --exclude-container container2
```

Closes #212 