### PR TITLE
Allow pods without labels to be selected in the resource query

### DIFF
--- a/stern/stern_test.go
+++ b/stern/stern_test.go
@@ -33,15 +33,6 @@ func TestRetrieveLabelsFromResource(t *testing.T) {
 	}
 	objs := []runtime.Object{
 		// core
-		&corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pod1",
-				Namespace: "ns1",
-				Labels: map[string]string{
-					"app": "pod-label",
-				},
-			},
-		},
 		&corev1.ReplicationController{
 			ObjectMeta: genMeta("rc1"),
 			Spec: corev1.ReplicationControllerSpec{
@@ -114,12 +105,6 @@ func TestRetrieveLabelsFromResource(t *testing.T) {
 		wantError bool
 	}{
 		// core
-		{
-			desc:  "pods",
-			kinds: []string{"po", "pods", "pod"},
-			name:  "pod1",
-			label: "pod-label",
-		},
 		{
 			desc:  "replicationcontrollers",
 			kinds: []string{"rc", "replicationcontrollers", "replicationcontroller"},


### PR DESCRIPTION
This PR allows pods without labels to be selected in the resource query.

Currently, we will get the following error when we specify a pod without labels.

```
$ stern pod/nolabel
Error: resource pod/nolabel has no labels to select
```

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: nolabel
spec:
  containers:
  - name: nginx
    image: nginx:1.23.3
```
