### PR TITLE
Add --max-log-requests flag to limit concurrent requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Supported Kubernetes resources are `pod`, `replicationcontroller`, `service`, `d
  `--include`, `-i`           | `[]`      | Log lines to include. (regular expression)
  `--init-containers`         | `true`    | Include or exclude init containers.
  `--kubeconfig`              |           | Path to kubeconfig file to use. Default to KUBECONFIG variable then ~/.kube/config path.
+ `--max-log-requests`        | `-1`      | Maximum number of concurrent logs to request. Defaults to 50, but 5 when specifying --no-follow
  `--namespace`, `-n`         |           | Kubernetes namespace to use. Default to namespace configured in kubernetes context. To specify multiple namespaces, repeat this or set comma-separated value.
  `--no-follow`               | `false`   | Exit when all logs have been shown.
  `--only-log-lines`          | `false`   | Print only log lines
@@ -146,6 +147,20 @@ You can configure the log level verbosity by the `--verbosity` flag.
 It is useful when you want to know how stern interacts with a Kubernetes API server in troubleshooting.
 
 Increasing the verbosity increases the number of logs. `--verbosity 6` would be a good starting point.
+
+### Max log requests
+
+Stern has the maximum number of concurrent logs to request to prevent unintentional load to a cluster.
+The number can be configured by the `--max-log-requests` flag.
+
+The behavior and the default are different depending on the presence of the `--no-follow` flag.
+
+| `--no-follow` | default | behavior         |
+|---------------|---------|------------------|
+| specified     | 5       | limits the number of concurrent logs to request |
+| not specified | 50      | exits with an error when if it reaches the concurrent limit |
+
+The combination of `--max-log-requests 1` and `--no-follow` will be helpful if you want to show logs in order.
 
 ## Examples:
 

--- a/stern/config.go
+++ b/stern/config.go
@@ -49,6 +49,7 @@ type Config struct {
 	Follow                bool
 	Resource              string
 	OnlyLogLines          bool
+	MaxLogRequests        int
 
 	Out    io.Writer
 	ErrOut io.Writer


### PR DESCRIPTION
Fixes https://github.com/stern/stern/issues/73

This PR adds the `--max-log-requests` flag to limit concurrent requests to prevent unintentional load to a cluster.

The behavior and the default are different depending on the presence of the `--no-follow` flag.

| `--no-follow` | default | behavior         |
|---------------|---------|------------------|
| specified     | 5       | limits the number of concurrent logs to request |
| not specified | 50      | exits with an error when if it reaches the concurrent limit |

## --no-follow specified
It limits the number of concurrent logs to request, so there is no apparent change.
I chose 5 for the default limit, the same as in kubectl.

:memo: I like the combination of `--max-log-requests 1` and `--no-follow`, which will show logs in order.

## --no-follow is not specified
It exits with an error when if it reaches the concurrent limit.
Though I am not sure how we should choose the default limit, I think 50 is enough for most cases.

```
$ dist/stern --max-log-requests 3 deployment/nginx
+ nginx-76d6c9b8c-77s2r › nginx
+ nginx-76d6c9b8c-cg85s › nginx
+ nginx-76d6c9b8c-lxpmt › nginx
Error: stern reached the maximum number of log requests (3), use --max-log-requests to increase the limit
```


