### PR TITLE
Change the default of --container-state to `all`

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Supported Kubernetes resources are `pod`, `replicationcontroller`, `service`, `d
  `--color`                   | `auto`    | Force set color output. 'auto':  colorize if tty attached, 'always': always colorize, 'never': never colorize.
  `--completion`              |           | Output stern command-line completion code for the specified shell. Can be 'bash', 'zsh' or 'fish'.
  `--container`, `-c`         | `.*`      | Container name when multiple containers in pod. (regular expression)
- `--container-state`         | `running` | Tail containers with state in running, waiting, terminated, or all. 'all' matches all container states. To specify multiple states, repeat this or set comma-separated value.
+ `--container-state`         | `all`     | Tail containers with state in running, waiting, terminated, or all. 'all' matches all container states. To specify multiple states, repeat this or set comma-separated value.
  `--context`                 |           | Kubernetes context to use. Default to current context configured in kubeconfig.
  `--ephemeral-containers`    | `true`    | Include or exclude ephemeral containers.
  `--exclude`, `-e`           | `[]`      | Log lines to exclude. (regular expression)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -79,7 +79,7 @@ func NewOptions(streams genericclioptions.IOStreams) *options {
 
 		color:               "auto",
 		container:           ".*",
-		containerStates:     []string{"running"},
+		containerStates:     []string{stern.ALL_STATES},
 		initContainers:      true,
 		ephemeralContainers: true,
 		output:              "default",

--- a/stern/container_state.go
+++ b/stern/container_state.go
@@ -41,7 +41,7 @@ func NewContainerState(stateConfig string) (ContainerState, error) {
 		return ALL_STATES, nil
 	}
 
-	return "", errors.New("containerState should be one of 'running', 'waiting', or 'terminated'")
+	return "", errors.New("containerState should be one of 'running', 'waiting', 'terminated', or 'all'")
 }
 
 // Match returns ContainerState is matched


### PR DESCRIPTION
This PR changes the default value of --container-state to [`all`](https://github.com/stern/stern/pull/222). It will be a breaking change.

Currently, the default value is `running`, so it does not show logs of completed pods (`terminated`) and CrashLoopBackoff pods (`waiting`). It is a bit [confusing](https://github.com/stern/stern/issues/36#issuecomment-1108906137) because `kubectl logs` shows logs regardless of their container statuses.

I don't know the exact reason why the default is `running`, but I guess it is because stern did not handle terminated containers well. By #221, stern can now handle terminated containers, so I would like to consider changing the default to `all`.