### PR TITLE
Support resuming from the last log when retrying

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	k8s.io/cli-runtime v0.26.0
 	k8s.io/client-go v0.26.0
 	k8s.io/klog/v2 v2.80.1
+	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448
 )
 
 require (
@@ -63,7 +64,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230109183929-3758b55a6596 // indirect
-	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kustomize/api v0.12.1 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.13.9 // indirect

--- a/stern/stern.go
+++ b/stern/stern.go
@@ -141,7 +141,7 @@ func Run(ctx context.Context, config *Config) error {
 		// We use a rate limiter to prevent a burst of retries.
 		// It also enables us to retry immediately, in most cases,
 		// when it is disconnected on the way.
-		limiter := rate.NewLimiter(rate.Every(time.Second*10), 3)
+		limiter := rate.NewLimiter(rate.Every(time.Second*20), 2)
 		var resumeRequest *ResumeRequest
 		for {
 			if err := limiter.Wait(ctx); err != nil {

--- a/stern/stern.go
+++ b/stern/stern.go
@@ -30,6 +30,7 @@ import (
 	"golang.org/x/time/rate"
 
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/utils/pointer"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -94,11 +95,10 @@ func Run(ctx context.Context, config *Config) error {
 		containerStates:        config.ContainerStates,
 	})
 	newTail := func(t *Target) *Tail {
-		sinceSeconds := int64(config.Since.Seconds())
 		return NewTail(client.CoreV1(), t.Node, t.Namespace, t.Pod, t.Container, config.Template, config.Out, config.ErrOut, &TailOptions{
 			Timestamps:   config.Timestamps,
 			Location:     config.Location,
-			SinceSeconds: &sinceSeconds,
+			SinceSeconds: pointer.Int64(int64(config.Since.Seconds())),
 			Exclude:      config.Exclude,
 			Include:      config.Include,
 			Namespace:    config.AllNamespaces || len(namespaces) > 1,

--- a/stern/tail.go
+++ b/stern/tail.go
@@ -183,6 +183,7 @@ func (t *Tail) Resume(ctx context.Context, resumeRequest *ResumeRequest) error {
 	t.resumeRequest = resumeRequest
 	t.Options.SinceTime = sinceTime
 	t.Options.SinceSeconds = nil
+	t.Options.TailLines = nil
 	return t.Start(ctx)
 }
 
@@ -291,16 +292,16 @@ func (t *Tail) consumeLine(line string) {
 		return
 	}
 
+	msg := content
 	if t.Options.Timestamps {
 		updatedTs, err := t.Options.UpdateTimezone(rfc3339Nano)
 		if err != nil {
 			t.Print(fmt.Sprintf("[%v] %s", err, line))
 			return
 		}
-		t.Print(updatedTs + " " + content)
-		return
+		msg = updatedTs + " " + msg
 	}
-	t.Print(content)
+	t.Print(msg)
 }
 
 func (t *Tail) rememberLastTimestamp(timestamp string) {

--- a/stern/tail_test.go
+++ b/stern/tail_test.go
@@ -5,13 +5,13 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"reflect"
 	"regexp"
 	"testing"
 	"text/template"
 	"time"
 
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/rest"
 )
 
 func TestDetermineColor(t *testing.T) {
@@ -62,81 +62,53 @@ func TestIsIncludeTestOptions(t *testing.T) {
 	}
 }
 
-func TestUpdateTimezoneIfNeeded(t *testing.T) {
+func TestUpdateTimezone(t *testing.T) {
 	location, _ := time.LoadLocation("Asia/Tokyo")
 
 	tests := []struct {
-		name        string
-		tailOptions *TailOptions
-		message     string
-		expected    string
-		err         string
+		name     string
+		message  string
+		expected string
+		err      string
 	}{
 		{
 			"normal case",
-			&TailOptions{
-				Timestamps: true,
-				Location:   location,
-			},
-			"2021-04-18T03:54:44.764981564Z Connection: keep-alive",
-			"2021-04-18T12:54:44.764981564+09:00 Connection: keep-alive",
+			"2021-04-18T03:54:44.764981564Z",
+			"2021-04-18T12:54:44.764981564+09:00",
 			"",
 		},
 		{
 			"padding",
-			&TailOptions{
-				Timestamps: true,
-				Location:   location,
-			},
-			"2021-04-18T03:54:44.764981500Z Connection: keep-alive",
-			"2021-04-18T12:54:44.764981500+09:00 Connection: keep-alive",
-			"",
-		},
-		{
-			"no timestamp",
-			&TailOptions{
-				Timestamps: false,
-				Location:   location,
-			},
-			"Connection: keep-alive",
-			"Connection: keep-alive",
+			"2021-04-18T03:54:44.764981500Z",
+			"2021-04-18T12:54:44.764981500+09:00",
 			"",
 		},
 		{
 			"timestamp required on non timestamp message",
-			&TailOptions{
-				Timestamps: true,
-				Location:   location,
-			},
-			"Connection: keep-alive",
-			"Connection: keep-alive",
+			"",
+			"",
 			"missing timestamp",
 		},
 		{
 			"not UTC",
-			&TailOptions{
-				Timestamps: true,
-				Location:   location,
-			},
-			"2021-08-03T01:26:29.953994922+02:00 Connection: keep-alive",
-			"2021-08-03T08:26:29.953994922+09:00 Connection: keep-alive",
+			"2021-08-03T01:26:29.953994922+02:00",
+			"2021-08-03T08:26:29.953994922+09:00",
 			"",
 		},
 		{
 			"RFC3339Nano format removed trailing zeros",
-			&TailOptions{
-				Timestamps: true,
-				Location:   location,
-			},
-			"2021-06-20T08:20:30.331385Z Connection: keep-alive",
-			"2021-06-20T17:20:30.331385000+09:00 Connection: keep-alive",
+			"2021-06-20T08:20:30.331385Z",
+			"2021-06-20T17:20:30.331385000+09:00",
 			"",
 		},
 	}
 
+	tailOptions := &TailOptions{
+		Location: location,
+	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			message, err := tt.tailOptions.UpdateTimezoneIfNeeded(tt.message)
+			message, err := tailOptions.UpdateTimezone(tt.message)
 			if tt.expected != message {
 				t.Errorf("expected %q, but actual %q", tt.expected, message)
 			}
@@ -149,19 +121,50 @@ func TestUpdateTimezoneIfNeeded(t *testing.T) {
 }
 
 func TestConsumeStreamTail(t *testing.T) {
+	logLines := `2023-02-13T21:20:30.000000001Z line 1
+2023-02-13T21:20:30.000000002Z line 2
+2023-02-13T21:20:31.000000001Z line 3
+2023-02-13T21:20:31.000000002Z line 4`
+	tmpl := template.Must(template.New("").Parse(`{{printf "%s (%s/%s/%s/%s)\n" .Message .NodeName .Namespace .PodName .ContainerName}}`))
+
 	tests := []struct {
-		tmpl     *template.Template
-		request  rest.ResponseWrapper
-		expected []byte
+		name      string
+		resumeReq *ResumeRequest
+		expected  []byte
 	}{
 		{
-			tmpl: template.Must(template.New("").Parse(`{{printf "%s (%s/%s/%s/%s)\n" .Message .NodeName .Namespace .PodName .ContainerName}}`)),
-			request: &responseWrapperMock{
-				data: bytes.NewBufferString(`line 1
-line 2
-line 3
-line 4`),
-			},
+			name: "normal",
+			expected: []byte(`line 1 (my-node/my-namespace/my-pod/my-container)
+line 2 (my-node/my-namespace/my-pod/my-container)
+line 3 (my-node/my-namespace/my-pod/my-container)
+line 4 (my-node/my-namespace/my-pod/my-container)
+`),
+		},
+		{
+			name:      "ResumeRequest LinesToSkip=1",
+			resumeReq: &ResumeRequest{Timestamp: "2023-02-13T21:20:30Z", LinesToSkip: 1},
+			expected: []byte(`line 2 (my-node/my-namespace/my-pod/my-container)
+line 3 (my-node/my-namespace/my-pod/my-container)
+line 4 (my-node/my-namespace/my-pod/my-container)
+`),
+		},
+		{
+			name:      "ResumeRequest LinesToSkip=2",
+			resumeReq: &ResumeRequest{Timestamp: "2023-02-13T21:20:30Z", LinesToSkip: 2},
+			expected: []byte(`line 3 (my-node/my-namespace/my-pod/my-container)
+line 4 (my-node/my-namespace/my-pod/my-container)
+`),
+		},
+		{
+			name:      "ResumeRequest LinesToSkip=3 (exceed)",
+			resumeReq: &ResumeRequest{Timestamp: "2023-02-13T21:20:30Z", LinesToSkip: 3},
+			expected: []byte(`line 3 (my-node/my-namespace/my-pod/my-container)
+line 4 (my-node/my-namespace/my-pod/my-container)
+`),
+		},
+		{
+			name:      "ResumeRequest does not match",
+			resumeReq: &ResumeRequest{Timestamp: "2222-22-22T21:20:30Z", LinesToSkip: 3},
 			expected: []byte(`line 1 (my-node/my-namespace/my-pod/my-container)
 line 2 (my-node/my-namespace/my-pod/my-container)
 line 3 (my-node/my-namespace/my-pod/my-container)
@@ -172,16 +175,18 @@ line 4 (my-node/my-namespace/my-pod/my-container)
 
 	clientset := fake.NewSimpleClientset()
 	for i, tt := range tests {
-		out := new(bytes.Buffer)
-		tail := NewTail(clientset.CoreV1(), "my-node", "my-namespace", "my-pod", "my-container", tt.tmpl, out, io.Discard, &TailOptions{})
+		t.Run(tt.name, func(t *testing.T) {
+			out := new(bytes.Buffer)
+			tail := NewTail(clientset.CoreV1(), "my-node", "my-namespace", "my-pod", "my-container", tmpl, out, io.Discard, &TailOptions{})
+			tail.resumeRequest = tt.resumeReq
+			if err := tail.ConsumeRequest(context.TODO(), &responseWrapperMock{data: bytes.NewBufferString(logLines)}); err != nil {
+				t.Fatalf("%d: unexpected err %v", i, err)
+			}
 
-		if err := tail.ConsumeRequest(context.TODO(), tt.request); err != nil {
-			t.Fatalf("%d: unexpected err %v", i, err)
-		}
-
-		if !bytes.Equal(tt.expected, out.Bytes()) {
-			t.Errorf("%d: expected %s, but actual %s", i, tt.expected, out)
-		}
+			if !bytes.Equal(tt.expected, out.Bytes()) {
+				t.Errorf("%d: expected %s, but actual %s", i, tt.expected, out)
+			}
+		})
 	}
 }
 
@@ -278,6 +283,85 @@ func TestPrintStopping(t *testing.T) {
 
 		if !bytes.Equal(tt.expected, errOut.Bytes()) {
 			t.Errorf("%d: expected %q, but actual %q", i, tt.expected, errOut)
+		}
+	}
+}
+
+func TestResumeRequestShouldSkip(t *testing.T) {
+	tests := []struct {
+		rr         ResumeRequest
+		timestamps []string
+		expected   []bool
+	}{
+		{
+			rr:         ResumeRequest{Timestamp: "t1", LinesToSkip: 1},
+			timestamps: []string{"t1", "t1"},
+			expected:   []bool{true, false},
+		},
+		{
+			rr:         ResumeRequest{Timestamp: "t1", LinesToSkip: 3},
+			timestamps: []string{"t1", "t1", "t1", "t1"},
+			expected:   []bool{true, true, true, false},
+		},
+		{
+			rr:         ResumeRequest{Timestamp: "t1", LinesToSkip: 3},
+			timestamps: []string{"t2", "t2"},
+			expected:   []bool{false, false},
+		},
+	}
+	for _, tt := range tests {
+		var actual []bool
+		for _, ts := range tt.timestamps {
+			actual = append(actual, tt.rr.shouldSkip(ts))
+		}
+		if !reflect.DeepEqual(tt.expected, actual) {
+			t.Errorf("expected %v, but actual %v", tt.expected, actual)
+		}
+	}
+}
+
+func TestRemoveSubsecond(t *testing.T) {
+	tests := []struct {
+		ts       string
+		expected string
+	}{
+		{
+			ts:       "2023-02-14T05:36:39.902767599Z",
+			expected: "2023-02-14T05:36:39Z",
+		},
+		{
+			ts:       "2023-02-14T05:36:39.1Z",
+			expected: "2023-02-14T05:36:39Z",
+		},
+		{
+			ts:       "2023-02-14T05:36:39Z",
+			expected: "2023-02-14T05:36:39Z",
+		},
+		{
+			ts:       "1.1",
+			expected: "1",
+		},
+		{
+			ts:       "10.1",
+			expected: "10",
+		},
+		{
+			ts:       "",
+			expected: "",
+		},
+		{
+			ts:       ".",
+			expected: ".",
+		},
+		{
+			ts:       ".1",
+			expected: "",
+		},
+	}
+	for _, tt := range tests {
+		actual := removeSubsecond(tt.ts)
+		if tt.expected != actual {
+			t.Errorf("expected %v, but actual %v", tt.expected, actual)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #229

This PR is to support resuming from the last log when retrying.

Here is the summary of the changes.

1. Always set PodLogOptions's Timestamps to true
    1. Print timestamps only when "--timestamps" is specified
1. Remember the last timestamp and line counts during this timestamp when printing log lines
    1. :memo: The timestamp in logs is RFC3339Nano, but PodLogOptions's SinceTime is RFC3339.
1. When resuming, set the last timestamp to PodLogOptions's SinceTime
    1. Skip lines we've already seen during the timestamp to avoid duplication

I found the rate limiter of retrying was not appropriate while I tested this feature, so I also tweaked it.

## How to test
The below steps are the way to test the resuming feature by restarting the kube-apiserver.

1. Deploy a pod that prints line numbers

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: counter
spec:
  terminationGracePeriodSeconds: 0
  containers:
  - name: c
    command:
    - /bin/sh
    - -c
    - |
      N=1
      while true; do
        for _ in $(seq 5); do
          echo "line $N"
          N=$((N+1))
        done
        sleep 10
      done
    image: busybox:1.36.0
```

2. Run stern to watch the pod

```
dist/stern pod/counter
```

```
+ counter › c
counter c line 1
counter c line 2
counter c line 3
counter c line 4
counter c line 5
```


3. Restart the kube-apiserver in another terminal

If you use kind, you can restart the kube-apiserver by the command below.

```
docker exec -it kind-control-plane /bin/bash -c 'kill -9 $(pgrep kube-apiserver)'
```

The connection will be disconnected, but it will retry soon and resume logs from the last line.

```
counter c line 15
counter c line 16
counter c line 17
counter c line 18
counter c line 19
counter c line 20
- counter › c
failed to tail: unexpected EOF, will retry
+ counter › c
- counter › c
failed to tail: Get "https://127.0.0.1:64321/api/v1/namespaces/default/pods/counter/log?container=c&follow=true&sinceTime=2023-02-17T04%3A50%3A38Z&timestamps=true": EOF, will retry
+ counter › c
- counter › c
failed to tail: Get "https://127.0.0.1:64321/api/v1/namespaces/default/pods/counter/log?container=c&follow=true&sinceTime=2023-02-17T04%3A50%3A38Z&timestamps=true": EOF, will retry
+ counter › c
counter c line 21
counter c line 22
counter c line 23
counter c line 24
counter c line 25
```
