### PR TITLE
Return error when output option is invalid

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -362,6 +362,8 @@ func (o *options) generateTemplate() (*template.Template, error) {
 				t = fmt.Sprintf("  \"namespace\": \"{{color .PodColor .Namespace}}\",\n%s", t)
 			}
 			t = fmt.Sprintf("{\n%s\n}", t)
+		default:
+			return nil, errors.New("output should be one of 'default', 'raw', 'json', 'extjson', and 'ppextjson'")
 		}
 		t += "\n"
 	}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -255,6 +255,18 @@ func TestOptionsGenerateTemplate(t *testing.T) {
 			false,
 		},
 		{
+			"invalid output",
+			func() *options {
+				o := NewOptions(streams)
+				o.output = "invalid"
+
+				return o
+			}(),
+			"message",
+			"",
+			true,
+		},
+		{
 			"template",
 			func() *options {
 				o := NewOptions(streams)


### PR DESCRIPTION
Fixes https://github.com/stern/stern/issues/234

This PR fixes a bug that prints empty lines when an invalid output option is specified.