### PR TITLE
Make CI jobs faster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ GOLANGCI_LINT_VERSION ?= v1.50.1
 GOLANGCI_LINT := $(TOOLS_BIN_DIR)/golangci-lint
 VALIDATE_KREW_MAIFEST_VERSION ?= v0.4.3
 VALIDATE_KREW_MAIFEST := $(TOOLS_BIN_DIR)/validate-krew-manifest
+GORELEASER_FILTER_VERSION ?= v0.3.0
+GORELEASER_FILTER := $(TOOLS_BIN_DIR)/goreleaser-filter
 
 $(GORELEASER):
 	GOBIN=$(TOOLS_BIN_DIR) go install github.com/goreleaser/goreleaser@$(GORELEASER_VERSION)
@@ -20,6 +22,9 @@ $(GOLANGCI_LINT):
 
 $(VALIDATE_KREW_MAIFEST):
 	GOBIN=$(TOOLS_BIN_DIR) go install sigs.k8s.io/krew/cmd/validate-krew-manifest@$(VALIDATE_KREW_MAIFEST_VERSION)
+
+$(GORELEASER_FILTER):
+	GOBIN=$(TOOLS_BIN_DIR) go install github.com/t0yv0/goreleaser-filter@$(GORELEASER_FILTER_VERSION)
 
 .PHONY: build-cross
 build-cross: $(GORELEASER)
@@ -56,7 +61,11 @@ validate-krew-manifest: $(VALIDATE_KREW_MAIFEST)
 	$(VALIDATE_KREW_MAIFEST) -manifest dist/stern.yaml -skip-install
 
 .PHONY: dist
-dist: $(GORELEASER)
+dist: $(GORELEASER) $(GORELEASER_FILTER)
+	cat .goreleaser.yaml | $(GORELEASER_FILTER) -goos $(shell go env GOOS) -goarch $(shell go env GOARCH) | $(GORELEASER) release -f- --rm-dist --skip-publish --snapshot
+
+.PHONY: dist-all
+dist-all: $(GORELEASER)
 	$(GORELEASER) release --rm-dist --skip-publish --snapshot
 
 .PHONY: release


### PR DESCRIPTION
This PR makes CI jobs faster.

We have a slow CI jobs problem because they target all GOOS and GOARCH to create artifacts. Here we use `goreleaser-filter` tool to make CI jobs faster by focusing on a single target.

- https://github.com/t0yv0/goreleaser-filter