### PR TITLE
Replace actions/cache with setup-go's cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,14 +16,9 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version: 1.19.x
+        cache: true
     - name: Ensure go.mod is already tidied
       run: go mod tidy && git diff -s --exit-code go.sum
-    - uses: actions/cache@v3
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
     - name: Run verify-readme
       run: make verify-readme
     - name: Run tests

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,12 +12,7 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version: 1.19.x
-    - uses: actions/cache@v3
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
+        cache: true
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v1
       with:


### PR DESCRIPTION
This PR replaces actions/cache with the [setup-go's cache feature](https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs) introduced in [setup-go v3.2.0](https://github.com/actions/setup-go/releases/tag/v3.2.0).

Currently, the [step of actions/cache on push](https://github.com/stern/stern/blob/4bb340d9ab24dcfbba82bb7e6a2b7760efe4385e/.github/workflows/ci.yaml#L21) seems not to work as expected, as [`go mod tidy` is called](https://github.com/stern/stern/blob/4bb340d9ab24dcfbba82bb7e6a2b7760efe4385e/.github/workflows/ci.yaml#L19) before that. This PR may also fix this issue.

<img width="957" alt="image" src="https://user-images.githubusercontent.com/9250296/221405184-0b726f55-e0fd-412a-8dfd-264fa6fb0493.png">
