### PR TITLE
allow flexible log parsing and formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ GOLANGCI_LINT_VERSION ?= v1.50.1
 GOLANGCI_LINT := $(TOOLS_BIN_DIR)/golangci-lint
 VALIDATE_KREW_MAIFEST_VERSION ?= v0.4.3
 VALIDATE_KREW_MAIFEST := $(TOOLS_BIN_DIR)/validate-krew-manifest
+GORELEASER_FILTER_VERSION ?= v0.3.0
+GORELEASER_FILTER := $(TOOLS_BIN_DIR)/goreleaser-filter
 
 $(GORELEASER):
 	GOBIN=$(TOOLS_BIN_DIR) go install github.com/goreleaser/goreleaser@$(GORELEASER_VERSION)
@@ -20,6 +22,9 @@ $(GOLANGCI_LINT):
 
 $(VALIDATE_KREW_MAIFEST):
 	GOBIN=$(TOOLS_BIN_DIR) go install sigs.k8s.io/krew/cmd/validate-krew-manifest@$(VALIDATE_KREW_MAIFEST_VERSION)
+
+$(GORELEASER_FILTER):
+	GOBIN=$(TOOLS_BIN_DIR) go install github.com/t0yv0/goreleaser-filter@$(GORELEASER_FILTER_VERSION)
 
 .PHONY: build-cross
 build-cross: $(GORELEASER)
@@ -56,7 +61,11 @@ validate-krew-manifest: $(VALIDATE_KREW_MAIFEST)
 	$(VALIDATE_KREW_MAIFEST) -manifest dist/stern.yaml -skip-install
 
 .PHONY: dist
-dist: $(GORELEASER)
+dist: $(GORELEASER) $(GORELEASER_FILTER)
+	cat .goreleaser.yaml | $(GORELEASER_FILTER) -goos $(shell go env GOOS) -goarch $(shell go env GOARCH) | $(GORELEASER) release -f- --rm-dist --skip-publish --snapshot
+
+.PHONY: dist-all
+dist-all: $(GORELEASER)
 	$(GORELEASER) release --rm-dist --skip-publish --snapshot
 
 .PHONY: release

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ stern --template='{{.PodName}}/{{.ContainerName}} {{with $d := .Message | parseJ
 Output using a custom template that tries to parse JSON or fallbacks to raw format:
 
 ```
-stern --template='{{.PodName}}/{{.ContainerName}} {{ with $msg := .Message | tryParseJSON }}[{{ colorGreen (toRFC3339Nano $msg.ts) }}] {{ levelColor $msg.level }} ({{ colorCyan $msg.caller }}) {{ $msg.msg }}{{ else }} {{ .Message }} {{ end }}{{"\n"}}' backend
+stern --template='{{.PodName}}/{{.ContainerName}} {{ with $msg := .Message | tryParseJSON }}[{{ colorGreen (toRFC3339Nano (toUTC $msg.ts)) }}] {{ levelColor $msg.level }} ({{ colorCyan $msg.caller }}) {{ $msg.msg }}{{ else }} {{ .Message }} {{ end }}{{"\n"}}' backend
 ```
 
 Load custom template from file:

--- a/README.md
+++ b/README.md
@@ -248,6 +248,18 @@ Output using a custom template with `parseJSON`:
 stern --template='{{.PodName}}/{{.ContainerName}} {{with $d := .Message | parseJSON}}[{{$d.level}}] {{$d.message}}{{end}}{{"\n"}}' backend
 ```
 
+Output using a custom template that tries to parse JSON or fallbacks to raw format:
+
+```
+stern --template='{{.PodName}}/{{.ContainerName}} {{ with $msg := .Message | tryParseJSON }}[{{ colorGreen (toRFC3339Nano $msg.ts) }}] {{ levelColor $msg.level }} ({{ colorCyan $msg.caller }}) {{ $msg.msg }}{{ else }} {{ .Message }} {{ end }}{{"\n"}}' backend
+```
+
+Load custom template from file:
+
+```
+stern --template-file=~/.stern.tpl backend
+```
+
 Trigger the interactive prompt to select an 'app.kubernetes.io/instance' label value:
 
 ```

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ stern --template='{{.PodName}}/{{.ContainerName}} {{with $d := .Message | parseJ
 Output using a custom template that tries to parse JSON or fallbacks to raw format:
 
 ```
-stern --template='{{.PodName}}/{{.ContainerName}} {{ with $msg := .Message | tryParseJSON }}[{{ colorGreen (toRFC3339Nano (toUTC $msg.ts)) }}] {{ levelColor $msg.level }} ({{ colorCyan $msg.caller }}) {{ $msg.msg }}{{ else }} {{ .Message }} {{ end }}{{"\n"}}' backend
+stern --template='{{.PodName}}/{{.ContainerName}} {{ with $msg := .Message | tryParseJSON }}[{{ colorGreen (toRFC3339Nano $msg.ts) }}] {{ levelColor $msg.level }} ({{ colorCyan $msg.caller }}) {{ $msg.msg }}{{ else }} {{ .Message }} {{ end }}{{"\n"}}' backend
 ```
 
 Load custom template from file:

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Supported Kubernetes resources are `pod`, `replicationcontroller`, `service`, `d
  `--since`, `-s`             | `48h0m0s` | Return logs newer than a relative duration like 5s, 2m, or 3h.
  `--tail`                    | `-1`      | The number of lines from the end of the logs to show. Defaults to -1, showing all logs.
  `--template`                |           | Template to use for log lines, leave empty to use --output flag.
- `--template-file`, `-T`     |           | Path to template to use for log lines, leave empty to use --output flag.
+ `--template-file`, `-T`     |           | Path to template to use for log lines, leave empty to use --output flag. It overrides --template option.
  `--timestamps`, `-t`        | `false`   | Print timestamps.
  `--timezone`                | `Local`   | Set timestamps to specific timezone.
  `--verbosity`               | `0`       | Number of the log level verbosity

--- a/README.md
+++ b/README.md
@@ -134,13 +134,25 @@ will receive the following struct:
 The following functions are available within the template (besides the [builtin
 functions](https://golang.org/pkg/text/template/#hdr-Functions)):
 
-| func        | arguments             | description                                                     |
-|-------------|-----------------------|-----------------------------------------------------------------|
-| `json`      | `object`              | Marshal the object and output it as a json text                 |
-| `color`     | `color.Color, string` | Wrap the text in color (.ContainerColor and .PodColor provided) |
-| `parseJSON` | `string`              | Parse string as JSON                                            |
-| `extjson`   | `string`              | Parse the object as json and output colorized json              |
-| `ppextjson` | `string`              | Parse the object as json and output pretty-print colorized json |
+| func            | arguments             | description                                                                       |
+|-----------------|-----------------------|-----------------------------------------------------------------------------------|
+| `json`          | `object`              | Marshal the object and output it as a json text                                   |
+| `color`         | `color.Color, string` | Wrap the text in color (.ContainerColor and .PodColor provided)                   |
+| `parseJSON`     | `string`              | Parse string as JSON                                                              |
+| `tryParseJSON`  | `string`              | Attemp to parse string as JSON, return nil on failure                             |
+| `extjson`       | `string`              | Parse the object as json and output colorized json                                |
+| `ppextjson`     | `string`              | Parse the object as json and output pretty-print colorized json                   |
+| `toRFC3339Nano` | `object`              | Parse timestamp (string, int, json.Number) and output it using RFC3339Nano format |
+| `levelColor`    | `string`              | Print log level using appropriate color                                           |
+| `colorBlack`    | `string`              | Print text using black color                                                      |
+| `colorRed`      | `string`              | Print text using red color                                                        |
+| `colorGreen`    | `string`              | Print text using green color                                                      |
+| `colorYellow`   | `string`              | Print text using yellow color                                                     |
+| `colorBlue`     | `string`              | Print text using blue color                                                       |
+| `colorMagenta`  | `string`              | Print text using magenta color                                                    |
+| `colorCyan`     | `string`              | Print text using cyan color                                                       |
+| `colorWhite`    | `string`              | Print text using white color                                                      |
+
 
 ### Log level verbosity
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Supported Kubernetes resources are `pod`, `replicationcontroller`, `service`, `d
  `--since`, `-s`             | `48h0m0s` | Return logs newer than a relative duration like 5s, 2m, or 3h.
  `--tail`                    | `-1`      | The number of lines from the end of the logs to show. Defaults to -1, showing all logs.
  `--template`                |           | Template to use for log lines, leave empty to use --output flag.
+ `--template-file`, `-T`     |           | Path to template to use for log lines, leave empty to use --output flag.
  `--timestamps`, `-t`        | `false`   | Print timestamps.
  `--timezone`                | `Local`   | Set timestamps to specific timezone.
  `--verbosity`               | `0`       | Number of the log level verbosity

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
+	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/stern/stern/stern"
@@ -366,6 +367,9 @@ func (o *options) generateTemplate() (*template.Template, error) {
 				return "", err
 			}
 			return strings.TrimSuffix(string(b), "\n"), nil
+		},
+		"formatTsRFC3339Nano": func(ts any) string {
+			return cast.ToTime(ts).Format(time.RFC3339Nano)
 		},
 		"color": func(color color.Color, text string) string {
 			return color.SprintFunc()(text)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -384,7 +384,7 @@ func (o *options) generateTemplate() (*template.Template, error) {
 			}
 			return strings.TrimSuffix(string(b), "\n"), nil
 		},
-		"formatTsRFC3339Nano": func(ts any) string {
+		"toRFC3339Nano": func(ts any) string {
 			return cast.ToTime(ts).Format(time.RFC3339Nano)
 		},
 		"color": func(color color.Color, text string) string {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -349,8 +349,6 @@ func (o *options) generateTemplate() (*template.Template, error) {
 		default:
 			return nil, errors.New("output should be one of 'default', 'raw', 'json', 'extjson', and 'ppextjson'")
 		}
-	}
-	if !strings.HasSuffix(t, "\n") {
 		t += "\n"
 	}
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -362,6 +362,13 @@ func (o *options) generateTemplate() (*template.Template, error) {
 			}
 			return string(b), nil
 		},
+		"tryParseJSON": func(text string) map[string]interface{} {
+			obj := make(map[string]interface{})
+			if err := json.Unmarshal([]byte(text), &obj); err != nil {
+				return nil
+			}
+			return obj
+		},
 		"parseJSON": func(text string) (map[string]interface{}, error) {
 			obj := make(map[string]interface{})
 			if err := json.Unmarshal([]byte(text), &obj); err != nil {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -337,6 +337,8 @@ func (o *options) generateTemplate() (*template.Template, error) {
 		default:
 			return nil, errors.New("output should be one of 'default', 'raw', 'json', 'extjson', and 'ppextjson'")
 		}
+	}
+	if !strings.HasSuffix(t, "\n") {
 		t += "\n"
 	}
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -306,7 +306,7 @@ func (o *options) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVarP(&o.since, "since", "s", o.since, "Return logs newer than a relative duration like 5s, 2m, or 3h.")
 	fs.Int64Var(&o.tail, "tail", o.tail, "The number of lines from the end of the logs to show. Defaults to -1, showing all logs.")
 	fs.StringVar(&o.template, "template", o.template, "Template to use for log lines, leave empty to use --output flag.")
-	fs.StringVarP(&o.templateFile, "template-file", "T", o.templateFile, "Path to template to use for log lines, leave empty to use --output flag.")
+	fs.StringVarP(&o.templateFile, "template-file", "T", o.templateFile, "Path to template to use for log lines, leave empty to use --output flag. It overrides --template option.")
 	fs.BoolVarP(&o.timestamps, "timestamps", "t", o.timestamps, "Print timestamps.")
 	fs.StringVar(&o.timezone, "timezone", o.timezone, "Set timestamps to specific timezone.")
 	fs.BoolVar(&o.onlyLogLines, "only-log-lines", o.onlyLogLines, "Print only log lines")

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -370,6 +370,35 @@ func (o *options) generateTemplate() (*template.Template, error) {
 		"color": func(color color.Color, text string) string {
 			return color.SprintFunc()(text)
 		},
+		"colorBlack":   color.BlackString,
+		"colorRed":     color.RedString,
+		"colorGreen":   color.GreenString,
+		"colorYellow":  color.YellowString,
+		"colorBlue":    color.BlueString,
+		"colorMagenta": color.MagentaString,
+		"colorCyan":    color.CyanString,
+		"colorWhite":   color.WhiteString,
+		"levelColor": func(level string) string {
+			var levelColor *color.Color
+			switch strings.ToLower(level) {
+			case "debug":
+				levelColor = color.New(color.FgMagenta)
+			case "info":
+				levelColor = color.New(color.FgBlue)
+			case "warn":
+				levelColor = color.New(color.FgYellow)
+			case "error":
+				levelColor = color.New(color.FgRed)
+			case "dpanic":
+				levelColor = color.New(color.FgRed)
+			case "panic":
+				levelColor = color.New(color.FgRed)
+			case "fatal":
+				levelColor = color.New(color.FgCyan)
+			default:
+			}
+			return levelColor.SprintFunc()(level)
+		},
 	}
 	template, err := template.New("log").Funcs(funs).Parse(t)
 	if err != nil {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -389,6 +389,9 @@ func (o *options) generateTemplate() (*template.Template, error) {
 		"toRFC3339Nano": func(ts any) string {
 			return cast.ToTime(ts).Format(time.RFC3339Nano)
 		},
+		"toUTC": func(ts any) time.Time {
+			return cast.ToTime(ts).UTC()
+		},
 		"color": func(color color.Color, text string) string {
 			return color.SprintFunc()(text)
 		},

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -2,12 +2,18 @@ package cmd
 
 import (
 	"bytes"
+	"reflect"
+	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/stern/stern/stern"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/utils/pointer"
 )
 
 func TestSternCommand(t *testing.T) {
@@ -323,6 +329,317 @@ func TestOptionsGenerateTemplate(t *testing.T) {
 			}
 			if want, got := tt.want, buf.String(); want != got {
 				t.Errorf("want %v, but got %v", want, got)
+			}
+		})
+	}
+}
+
+func TestOptionsSternConfig(t *testing.T) {
+	streams := genericclioptions.NewTestIOStreamsDiscard()
+
+	local, _ := time.LoadLocation("Local")
+	utc, _ := time.LoadLocation("UTC")
+	labelSelector, _ := labels.Parse("l=sel")
+	fieldSelector, _ := fields.ParseSelector("f=field")
+
+	re := regexp.MustCompile
+
+	defaultConfig := func() *stern.Config {
+		return &stern.Config{
+			KubeConfig:            "",
+			ContextName:           "",
+			Namespaces:            []string{},
+			PodQuery:              re(""),
+			ExcludePodQuery:       nil,
+			Timestamps:            false,
+			Location:              local,
+			ContainerQuery:        re(".*"),
+			ExcludeContainerQuery: nil,
+			ContainerStates:       []stern.ContainerState{stern.ALL_STATES},
+			Exclude:               nil,
+			Include:               nil,
+			InitContainers:        true,
+			EphemeralContainers:   true,
+			Since:                 48 * time.Hour,
+			AllNamespaces:         false,
+			LabelSelector:         labels.Everything(),
+			FieldSelector:         fields.Everything(),
+			TailLines:             nil,
+			Template:              nil, // ignore when comparing
+			Follow:                true,
+			Resource:              "",
+			OnlyLogLines:          false,
+			MaxLogRequests:        50,
+
+			Out:    streams.Out,
+			ErrOut: streams.ErrOut,
+		}
+	}
+
+	tests := []struct {
+		name      string
+		o         *options
+		want      *stern.Config
+		wantError bool
+	}{
+		{
+			"default",
+			NewOptions(streams),
+			defaultConfig(),
+			false,
+		},
+		{
+			"change all options",
+			func() *options {
+				o := NewOptions(streams)
+				o.kubeConfig = "kubeconfig1"
+				o.context = "context1"
+				o.namespaces = []string{"ns1", "ns2"}
+				o.podQuery = "query1"
+				o.excludePod = []string{"exp1", "exp2"}
+				o.timestamps = true
+				o.timezone = "UTC" // Location
+				o.container = "container1"
+				o.excludeContainer = []string{"exc1", "exc2"}
+				o.containerStates = []string{"running", "terminated"}
+				o.exclude = []string{"ex1", "ex2"}
+				o.include = []string{"in1", "in2"}
+				o.initContainers = false
+				o.ephemeralContainers = false
+				o.since = 1 * time.Hour
+				o.allNamespaces = true
+				o.selector = "l=sel"
+				o.fieldSelector = "f=field"
+				o.tail = 10
+				o.noFollow = true // Follow = false
+				o.maxLogRequests = 30
+				o.resource = "res1"
+				o.onlyLogLines = true
+
+				return o
+			}(),
+			func() *stern.Config {
+				c := defaultConfig()
+				c.KubeConfig = "kubeconfig1"
+				c.ContextName = "context1"
+				c.Namespaces = []string{"ns1", "ns2"}
+				c.PodQuery = re("query1")
+				c.ExcludePodQuery = []*regexp.Regexp{re("exp1"), re("exp2")}
+				c.Timestamps = true
+				c.Location = utc
+				c.ContainerQuery = re("container1")
+				c.ExcludeContainerQuery = []*regexp.Regexp{re("exc1"), re("exc2")}
+				c.ContainerStates = []stern.ContainerState{stern.RUNNING, stern.TERMINATED}
+				c.Exclude = []*regexp.Regexp{re("ex1"), re("ex2")}
+				c.Include = []*regexp.Regexp{re("in1"), re("in2")}
+				c.InitContainers = false
+				c.EphemeralContainers = false
+				c.Since = 1 * time.Hour
+				c.AllNamespaces = true
+				c.LabelSelector = labelSelector
+				c.FieldSelector = fieldSelector
+				c.TailLines = pointer.Int64(10)
+				c.Follow = false
+				c.Resource = "res1"
+				c.OnlyLogLines = true
+				c.MaxLogRequests = 30
+
+				return c
+			}(),
+			false,
+		},
+		{
+			"noFollow has the different default",
+			func() *options {
+				o := NewOptions(streams)
+				o.noFollow = true // Follow = false
+
+				return o
+			}(),
+			func() *stern.Config {
+				c := defaultConfig()
+				c.Follow = false
+				c.MaxLogRequests = 5 // default of noFollow
+
+				return c
+			}(),
+			false,
+		},
+		{
+			"nil should be allowed",
+			func() *options {
+				o := NewOptions(streams)
+				o.excludePod = nil
+				o.excludeContainer = nil
+				o.containerStates = nil
+				o.namespaces = nil
+				o.exclude = nil
+				o.include = nil
+
+				return o
+			}(),
+			func() *stern.Config {
+				c := defaultConfig()
+				c.ContainerStates = []stern.ContainerState{}
+
+				return c
+			}(),
+			false,
+		},
+		{
+			"error podQuery",
+			func() *options {
+				o := NewOptions(streams)
+				o.podQuery = "[invalid"
+
+				return o
+			}(),
+			nil,
+			true,
+		},
+		{
+			"error excludePod",
+			func() *options {
+				o := NewOptions(streams)
+				o.excludePod = []string{"exp1", "[invalid"}
+
+				return o
+			}(),
+			nil,
+			true,
+		},
+		{
+			"error container",
+			func() *options {
+				o := NewOptions(streams)
+				o.container = "[invalid"
+
+				return o
+			}(),
+			nil,
+			true,
+		},
+		{
+			"error excludeContainer",
+			func() *options {
+				o := NewOptions(streams)
+				o.excludeContainer = []string{"exc1", "[invalid"}
+
+				return o
+			}(),
+			nil,
+			true,
+		},
+		{
+			"error exclude",
+			func() *options {
+				o := NewOptions(streams)
+				o.exclude = []string{"ex1", "[invalid"}
+
+				return o
+			}(),
+			nil,
+			true,
+		},
+		{
+			"error include",
+			func() *options {
+				o := NewOptions(streams)
+				o.include = []string{"in1", "[invalid"}
+
+				return o
+			}(),
+			nil,
+			true,
+		},
+		{
+			"error containerStates",
+			func() *options {
+				o := NewOptions(streams)
+				o.containerStates = []string{"running", "invalid"}
+
+				return o
+			}(),
+			nil,
+			true,
+		},
+		{
+			"error selector",
+			func() *options {
+				o := NewOptions(streams)
+				o.selector = "-"
+
+				return o
+			}(),
+			nil,
+			true,
+		},
+		{
+			"error fieldSelector",
+			func() *options {
+				o := NewOptions(streams)
+				o.fieldSelector = "-"
+
+				return o
+			}(),
+			nil,
+			true,
+		},
+		{
+			"error color",
+			func() *options {
+				o := NewOptions(streams)
+				o.color = "invalid"
+
+				return o
+			}(),
+			nil,
+			true,
+		},
+		{
+			"error output",
+			func() *options {
+				o := NewOptions(streams)
+				o.output = "invalid"
+
+				return o
+			}(),
+			nil,
+			true,
+		},
+		{
+			"error timezone",
+			func() *options {
+				o := NewOptions(streams)
+				o.timezone = "invalid"
+
+				return o
+			}(),
+			nil,
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.o.sternConfig()
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("expected error, but got no error")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			// We skip the template as it is difficult to check
+			// and is tested in TestOptionsGenerateTemplate().
+			got.Template = nil
+
+			if !reflect.DeepEqual(tt.want, got) {
+				t.Errorf("want %+v, but got %+v", tt.want, got)
 			}
 		})
 	}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -296,6 +296,42 @@ func TestOptionsGenerateTemplate(t *testing.T) {
 			"",
 			true,
 		},
+		{
+			"template-file",
+			func() *options {
+				o := NewOptions(streams)
+				o.templateFile = "test.tpl"
+
+				return o
+			}(),
+			"template message",
+			"pod1 container1 template message",
+			false,
+		},
+		{
+			"template-file-json-log-ts-float",
+			func() *options {
+				o := NewOptions(streams)
+				o.templateFile = "test.tpl"
+
+				return o
+			}(),
+			`{"ts": 123, "level": "INFO", "msg": "template message"}`,
+			"pod1 container1 [1970-01-01T00:02:03Z] INFO template message",
+			false,
+		},
+		{
+			"template-file-json-log-ts-str",
+			func() *options {
+				o := NewOptions(streams)
+				o.templateFile = "test.tpl"
+
+				return o
+			}(),
+			`{"ts": "1970-01-01T01:02:03+01:00", "level": "INFO", "msg": "template message"}`,
+			"pod1 container1 [1970-01-01T00:02:03Z] INFO template message",
+			false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/test.tpl
+++ b/cmd/test.tpl
@@ -1,0 +1,1 @@
+{{color .PodColor .PodName}} {{color .ContainerColor .ContainerName}} {{ with $msg := .Message | tryParseJSON }}[{{ colorGreen (toRFC3339Nano (toUTC $msg.ts)) }}] {{ levelColor $msg.level }} {{ $msg.msg }}{{ else }}{{ .Message }}{{ end }}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/fatih/color v1.13.0
 	github.com/pkg/errors v0.9.1
+	github.com/spf13/cast v1.5.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/sync v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,7 @@ github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLi
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/flowstack/go-jsonschema v0.1.1/go.mod h1:yL7fNggx1o8rm9RlgXv7hTBWxdBM0rVwpMwimd3F3N0=
+github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
@@ -109,8 +110,8 @@ github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:C
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
-github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -151,9 +152,12 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
+github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
+github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=
+github.com/spf13/cast v1.5.0/go.mod h1:SpXXQ5YoyJw6s3/6cMTQuxvgRl3PCJiyaX9p6b155UU=
 github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
 github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=


### PR DESCRIPTION
Addresses https://github.com/stern/stern/issues/227

This is an alternative solution to https://github.com/stern/stern/pull/228

Instead of hardcoding template in the code, I suggest adding a bunch of helper functions and a way to load template from disk.

This PR adds:
 * various color functions
 * TS format function `formatTsRFC3339Nano`
 * `tryParseJSON` function that does not return an error
 * `--template-file/-T` to load template from disk

Sample template that I use:
```
{{color .PodColor .PodName}} {{color .ContainerColor .ContainerName}} {{ with $msg := .Message | tryParseJSON }}[{{ colorGreen (formatTsRFC3339Nano $msg.ts) }}] {{ levelColor $msg.level }} ({{ colorCyan $msg.caller }}) {{ $msg.msg }}{{ else }} {{ .Message }} {{ end }}
```

It allows me to have an alias `alias stern="stern -T ~/.stern.tpl"` which support parsing both JSON and non-JSON logs.