### PR TITLE
Add CI for skipped files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  # Must keep in sync with ci_for_skipped.yaml
   push:
     branches: [master]
     paths-ignore: ['**.md']

--- a/.github/workflows/ci_for_skipped.yaml
+++ b/.github/workflows/ci_for_skipped.yaml
@@ -1,0 +1,16 @@
+# CI for skipped files
+name: CI
+
+on:
+  push:
+    branches: [master]
+    paths: ['**.md']
+  pull_request:
+    types: [opened, synchronize]
+    paths: ['**.md']
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - run: 'echo "No check required"'


### PR DESCRIPTION
This PR adds CI for skipped files. It allows us to merge PRs that only change README.md

Please see [Handling skipped but required checks](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks) for details.
