### PR TITLE
Add --node flag to filter on a specific node

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Supported Kubernetes resources are `pod`, `replicationcontroller`, `service`, `d
  `--max-log-requests`        | `-1`      | Maximum number of concurrent logs to request. Defaults to 50, but 5 when specifying --no-follow
  `--namespace`, `-n`         |           | Kubernetes namespace to use. Default to namespace configured in kubernetes context. To specify multiple namespaces, repeat this or set comma-separated value.
  `--no-follow`               | `false`   | Exit when all logs have been shown.
+ `--node`                    |           | Node name to filter on.
  `--only-log-lines`          | `false`   | Print only log lines
  `--output`, `-o`            | `default` | Specify predefined template. Currently support: [default, raw, json, extjson, ppextjson]
  `--prompt`, `-p`            | `false`   | Toggle interactive prompt for selecting 'app.kubernetes.io/instance' label values.

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -376,7 +376,7 @@ func TestOptionsSternConfig(t *testing.T) {
 	local, _ := time.LoadLocation("Local")
 	utc, _ := time.LoadLocation("UTC")
 	labelSelector, _ := labels.Parse("l=sel")
-	fieldSelector, _ := fields.ParseSelector("f=field")
+	fieldSelector, _ := fields.ParseSelector("f=field,spec.nodeName=node1")
 
 	re := regexp.MustCompile
 
@@ -451,6 +451,7 @@ func TestOptionsSternConfig(t *testing.T) {
 				o.maxLogRequests = 30
 				o.resource = "res1"
 				o.onlyLogLines = true
+				o.node = "node1"
 
 				return o
 			}(),
@@ -479,6 +480,40 @@ func TestOptionsSternConfig(t *testing.T) {
 				c.Resource = "res1"
 				c.OnlyLogLines = true
 				c.MaxLogRequests = 30
+
+				return c
+			}(),
+			false,
+		},
+		{
+			"fieldSelector without node",
+			func() *options {
+				o := NewOptions(streams)
+				o.fieldSelector = "f=field"
+
+				return o
+			}(),
+			func() *stern.Config {
+				c := defaultConfig()
+				sel, _ := fields.ParseSelector("f=field")
+				c.FieldSelector = sel
+
+				return c
+			}(),
+			false,
+		},
+		{
+			"node without fieldSelector",
+			func() *options {
+				o := NewOptions(streams)
+				o.node = "node1"
+
+				return o
+			}(),
+			func() *stern.Config {
+				c := defaultConfig()
+				sel, _ := fields.ParseSelector("spec.nodeName=node1")
+				c.FieldSelector = sel
 
 				return c
 			}(),


### PR DESCRIPTION
ref #242

This PR adds `--node` flag to filter on a specific node. This flag will be helpful when we debug pods on the specific node.

```
# Print a DaemonSet pod on the specific node
stern --node <NODE_NAME> daemonsets/<DS_NAME>

# Print all pods on the specific node
stern --node <NODE_NAME> --all-namespaces --no-follow --max-log-requests 1 .
```

I will implement a completion for this flag after this PR is merged.

### Example

Let's say we have four nodes.

```
$ kubectl get nodes
NAME                 STATUS   ROLES           AGE   VERSION
kind-control-plane   Ready    control-plane   14m   v1.25.3
kind-worker          Ready    <none>          13m   v1.25.3
kind-worker2         Ready    <none>          13m   v1.25.3
kind-worker3         Ready    <none>          13m   v1.25.3
```

Without `--node`, stern shows all pods that the DaemonSet created.

```
$ stern -n kube-system --tail 1 --no-follow --only-log-lines daemonset/kindnet
kindnet-flqlg kindnet-cni I0305 01:34:00.843821       1 main.go:250] Node kind-worker3 has CIDR [10.244.1.0/24]
kindnet-5f4ms kindnet-cni I0305 01:33:59.442694       1 main.go:250] Node kind-worker3 has CIDR [10.244.1.0/24]
kindnet-bdgk4 kindnet-cni I0305 01:33:59.039534       1 main.go:227] handling current node
kindnet-hqn2k kindnet-cni I0305 01:33:59.268987       1 main.go:250] Node kind-worker3 has CIDR [10.244.1.0/24]
```

With `--node kind-worker2`, stern shows only the pod on the node `kind-worker2`.

```
$ stern --node kind-worker2 -n kube-system --tail 1 --no-follow --only-log-lines daemonset/kindnet
kindnet-hqn2k kindnet-cni I0305 01:36:19.251494       1 main.go:250] Node kind-worker3 has CIDR [10.244.1.0/24]
```
