### PR TITLE
Add dynamic completion for --node flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ stern . --only-log-lines
 Stern supports command-line auto completion for bash, zsh or fish. `stern
 --completion=(bash|zsh|fish)` outputs the shell completion code which work by being
 evaluated in `.bashrc`, etc for the specified shell. In addition, Stern
-supports dynamic completion for `--namespace`, `--context`, a resource query
+supports dynamic completion for `--namespace`, `--context`, `--node`, a resource query
 in the form `<resource>/<name>`, and flags with pre-defined choices.
 
 If you use bash, stern bash completion code depends on the


### PR DESCRIPTION
Fixes https://github.com/stern/stern/issues/242
This PR adds a dynamic completion for `--node` flag.

https://user-images.githubusercontent.com/9250296/222941344-5afd32a3-3913-45df-9b98-ecba6aa27bbf.mov