### PR TITLE
Add a short format for timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Supported Kubernetes resources are `pod`, `replicationcontroller`, `service`, `d
  `--tail`                    | `-1`      | The number of lines from the end of the logs to show. Defaults to -1, showing all logs.
  `--template`                |           | Template to use for log lines, leave empty to use --output flag.
  `--template-file`, `-T`     |           | Path to template to use for log lines, leave empty to use --output flag. It overrides --template option.
- `--timestamps`, `-t`        | `false`   | Print timestamps.
+ `--timestamps`, `-t`        |           | Print timestamps with the specified format. One of 'default' or 'short'. If specified but without value, 'default' is used.
  `--timezone`                | `Local`   | Set timestamps to specific timezone.
  `--verbosity`               | `0`       | Number of the log level verbosity
  `--version`, `-v`           | `false`   | Print the version and exit.

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -388,6 +388,7 @@ func TestOptionsSternConfig(t *testing.T) {
 			PodQuery:              re(""),
 			ExcludePodQuery:       nil,
 			Timestamps:            false,
+			TimestampFormat:       "",
 			Location:              local,
 			ContainerQuery:        re(".*"),
 			ExcludeContainerQuery: nil,
@@ -433,7 +434,7 @@ func TestOptionsSternConfig(t *testing.T) {
 				o.namespaces = []string{"ns1", "ns2"}
 				o.podQuery = "query1"
 				o.excludePod = []string{"exp1", "exp2"}
-				o.timestamps = true
+				o.timestamps = "default"
 				o.timezone = "UTC" // Location
 				o.container = "container1"
 				o.excludeContainer = []string{"exc1", "exc2"}
@@ -463,6 +464,7 @@ func TestOptionsSternConfig(t *testing.T) {
 				c.PodQuery = re("query1")
 				c.ExcludePodQuery = []*regexp.Regexp{re("exp1"), re("exp2")}
 				c.Timestamps = true
+				c.TimestampFormat = stern.TimestampFormatDefault
 				c.Location = utc
 				c.ContainerQuery = re("container1")
 				c.ExcludeContainerQuery = []*regexp.Regexp{re("exc1"), re("exc2")}
@@ -514,6 +516,23 @@ func TestOptionsSternConfig(t *testing.T) {
 				c := defaultConfig()
 				sel, _ := fields.ParseSelector("spec.nodeName=node1")
 				c.FieldSelector = sel
+
+				return c
+			}(),
+			false,
+		},
+		{
+			"timestamp=short",
+			func() *options {
+				o := NewOptions(streams)
+				o.timestamps = "short"
+
+				return o
+			}(),
+			func() *stern.Config {
+				c := defaultConfig()
+				c.Timestamps = true
+				c.TimestampFormat = stern.TimestampFormatShort
 
 				return c
 			}(),
@@ -683,6 +702,17 @@ func TestOptionsSternConfig(t *testing.T) {
 			func() *options {
 				o := NewOptions(streams)
 				o.timezone = "invalid"
+
+				return o
+			}(),
+			nil,
+			true,
+		},
+		{
+			"error timestamps",
+			func() *options {
+				o := NewOptions(streams)
+				o.timestamps = "invalid"
 
 				return o
 			}(),

--- a/cmd/flag_completion.go
+++ b/cmd/flag_completion.go
@@ -34,6 +34,7 @@ var flagChoices = map[string][]string{
 	"completion":      []string{"bash", "zsh", "fish"},
 	"container-state": []string{stern.RUNNING, stern.WAITING, stern.TERMINATED, stern.ALL_STATES},
 	"output":          []string{"default", "raw", "json", "extjson", "ppextjson"},
+	"timestamps":      []string{"default", "short"},
 }
 
 func runCompletion(shell string, cmd *cobra.Command, out io.Writer) error {

--- a/stern/config.go
+++ b/stern/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	PodQuery              *regexp.Regexp
 	ExcludePodQuery       []*regexp.Regexp
 	Timestamps            bool
+	TimestampFormat       string
 	Location              *time.Location
 	ContainerQuery        *regexp.Regexp
 	ExcludeContainerQuery []*regexp.Regexp

--- a/stern/stern.go
+++ b/stern/stern.go
@@ -96,15 +96,16 @@ func Run(ctx context.Context, config *Config) error {
 	})
 	newTail := func(t *Target) *Tail {
 		return NewTail(client.CoreV1(), t.Node, t.Namespace, t.Pod, t.Container, config.Template, config.Out, config.ErrOut, &TailOptions{
-			Timestamps:   config.Timestamps,
-			Location:     config.Location,
-			SinceSeconds: pointer.Int64(int64(config.Since.Seconds())),
-			Exclude:      config.Exclude,
-			Include:      config.Include,
-			Namespace:    config.AllNamespaces || len(namespaces) > 1,
-			TailLines:    config.TailLines,
-			Follow:       config.Follow,
-			OnlyLogLines: config.OnlyLogLines,
+			Timestamps:      config.Timestamps,
+			TimestampFormat: config.TimestampFormat,
+			Location:        config.Location,
+			SinceSeconds:    pointer.Int64(int64(config.Since.Seconds())),
+			Exclude:         config.Exclude,
+			Include:         config.Include,
+			Namespace:       config.AllNamespaces || len(namespaces) > 1,
+			TailLines:       config.TailLines,
+			Follow:          config.Follow,
+			OnlyLogLines:    config.OnlyLogLines,
 		})
 	}
 

--- a/stern/tail_test.go
+++ b/stern/tail_test.go
@@ -63,23 +63,26 @@ func TestIsIncludeTestOptions(t *testing.T) {
 	}
 }
 
-func TestUpdateTimezone(t *testing.T) {
+func TestUpdateTimezoneAndFormat(t *testing.T) {
 	location, _ := time.LoadLocation("Asia/Tokyo")
 
 	tests := []struct {
 		name     string
+		format   string
 		message  string
 		expected string
 		err      string
 	}{
 		{
 			"normal case",
+			"", // default format is used if empty
 			"2021-04-18T03:54:44.764981564Z",
 			"2021-04-18T12:54:44.764981564+09:00",
 			"",
 		},
 		{
 			"padding",
+			"",
 			"2021-04-18T03:54:44.764981500Z",
 			"2021-04-18T12:54:44.764981500+09:00",
 			"",
@@ -88,28 +91,40 @@ func TestUpdateTimezone(t *testing.T) {
 			"timestamp required on non timestamp message",
 			"",
 			"",
+			"",
 			"missing timestamp",
 		},
 		{
 			"not UTC",
+			"",
 			"2021-08-03T01:26:29.953994922+02:00",
 			"2021-08-03T08:26:29.953994922+09:00",
 			"",
 		},
 		{
 			"RFC3339Nano format removed trailing zeros",
+			"",
 			"2021-06-20T08:20:30.331385Z",
 			"2021-06-20T17:20:30.331385000+09:00",
 			"",
 		},
+		{
+			"Specified the short format",
+			TimestampFormatShort,
+			"2021-06-20T08:20:30.331385Z",
+			"06-20 17:20:30",
+			"",
+		},
 	}
 
-	tailOptions := &TailOptions{
-		Location: location,
-	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			message, err := tailOptions.UpdateTimezone(tt.message)
+			tailOptions := &TailOptions{
+				Location:        location,
+				TimestampFormat: tt.format,
+			}
+
+			message, err := tailOptions.UpdateTimezoneAndFormat(tt.message)
 			if tt.expected != message {
 				t.Errorf("expected %q, but actual %q", tt.expected, message)
 			}


### PR DESCRIPTION
Fixes https://github.com/stern/stern/issues/247

This PR adds a short format for timestamps. 

It made `--timestamps` take a format, one of "default" or "short" in the form of `--timestamps=<format>`.

- `default`: the original format `2006-01-02T15:04:05.000000000Z07:00` (RFC3339Nano with trailing zeros)
- `short`: the new format `01-02 15:04:05` (time.DateTime without year).

If `--timestamps` is specified but without value, "default" is used to maintain backward compatibility.

## Example

With `--timestamps=short`, stern shows timestamps in the short format.

```
$ stern --timestamps=short -n kube-system ds/kindnet --no-follow --tail 1 --only-log-lines
kindnet-hqn2k kindnet-cni 03-12 09:29:53 I0312 00:29:53.620499       1 main.go:250] Node kind-worker3 has CIDR [10.244.1.0/24]
kindnet-5f4ms kindnet-cni 03-12 09:29:53 I0312 00:29:53.374482       1 main.go:250] Node kind-worker3 has CIDR [10.244.1.0/24]
```

With `--timestamps` (specified but without value), stern shows timestamps in the original format.

```
$ stern --timestamps -n kube-system ds/kindnet --no-follow --tail 1 --only-log-lines
kindnet-hqn2k kindnet-cni 2023-03-12T09:29:33.637476100+09:00 I0312 00:29:33.637404       1 main.go:250] Node kind-worker3 has CIDR [10.244.1.0/24]
kindnet-5f4ms kindnet-cni 2023-03-12T09:29:33.394264800+09:00 I0312 00:29:33.394135       1 main.go:250] Node kind-worker3 has CIDR [10.244.1.0/24]
```
