### PR TITLE
Make setup-go get Go version from go.mod

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: 1.19.x
+        go-version-file: go.mod
         cache: true
     - name: Ensure go.mod is already tidied
       run: go mod tidy && git diff -s --exit-code go.sum

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: 1.19.x
+        go-version-file: go.mod
         cache: true
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v1


### PR DESCRIPTION
This PR makes setup-go [get the Go version from go.mod](https://github.com/actions/setup-go#getting-go-version-from-the-gomod-file). It will eliminate the possibility of forgetting to update the Go version in the workflow files.

