### PR TITLE
Allow an empty config file

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	goflag "flag"
 	"fmt"
+	"io"
 	"os"
 	"regexp"
 	"strconv"
@@ -321,7 +322,7 @@ func (o *options) overrideFlagSetDefaultFromConfig(fs *pflag.FlagSet) error {
 
 	data := make(map[string]interface{})
 
-	if err := yaml.NewDecoder(configFile).Decode(data); err != nil {
+	if err := yaml.NewDecoder(configFile).Decode(data); err != nil && err != io.EOF {
 		return err
 	}
 

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -813,6 +813,12 @@ func TestOptionsOverrideFlagSetDefaultFromConfig(t *testing.T) {
 			wantErr:                 false,
 		},
 		{
+			name:                    "--config=testdata/config-empty.yaml",
+			flagConfigFilePathValue: filepath.Join(wd, "testdata/config-empty.yaml"),
+			expectedTailValue:       -1,
+			wantErr:                 false,
+		},
+		{
 			name:                    "--config=config-not-exist.yaml",
 			flagConfigFilePathValue: filepath.Join(wd, "config-not-exist.yaml"),
 			wantErr:                 true,


### PR DESCRIPTION
This PR allows an empty config file. Currently, stern fails as follows when the config file is empty. Please see https://github.com/go-yaml/yaml/issues/639 for details.

```
$ touch /tmp/empty-sternconfig.yaml

$ dist/stern --config /tmp/empty-sternconfig.yaml .
Error: EOF
Usage:
  stern pod-query [flags]
# ...
```
