### PR TITLE
Update Github Actions dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,10 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@v4
       with:
         go-version-file: go.mod
-        cache: true
     - name: Ensure go.mod is already tidied
       run: go mod tidy && git diff -s --exit-code go.sum
     - name: Run verify-readme

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,12 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@v4
       with:
         go-version-file: go.mod
-        cache: true
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -24,6 +23,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Update new version in krew-index
-      uses: rajatjindal/krew-release-bot@v0.0.43
+      uses: rajatjindal/krew-release-bot@v0.0.46
       with:
         krew_template_file: dist/stern.yaml


### PR DESCRIPTION
This PR updates the GitHub Actions dependencies. It will resolve deprecation warnings by docker/login-action@v1 as well.

https://github.com/stern/stern/actions/runs/4694590846

<img width="984" alt="image" src="https://user-images.githubusercontent.com/9250296/231912700-f96909d2-fe3d-492e-835a-6076d2f8b899.png">