### PR TITLE
Integrate fmt and vet checks into golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,13 @@
+run:
+  timeout: 5m
+linters:
+  disable-all: true
+  enable:
+  - errcheck
+  - gofmt
+  - gosimple
+  - govet
+  - ineffassign
+  - staticcheck
+  - typecheck
+  - unused

--- a/Makefile
+++ b/Makefile
@@ -31,20 +31,16 @@ build-cross: $(GORELEASER)
 	$(GORELEASER) build --snapshot --clean
 
 .PHONY: test
-test: fmt vet lint
+test: lint
 	go test -v ./...
 
 .PHONY: lint
 lint: $(GOLANGCI_LINT)
 	$(GOLANGCI_LINT) run
 
-.PHONY: fmt
-fmt:
-	go fmt ./...
-
-.PHONY: vet
-vet:
-	go vet ./...
+.PHONY: lint-fix
+lint-fix: $(GOLANGCI_LINT)
+	$(GOLANGCI_LINT) run --fix
 
 README_FILE ?= ./README.md
 

--- a/cmd/flag_completion.go
+++ b/cmd/flag_completion.go
@@ -30,11 +30,11 @@ import (
 )
 
 var flagChoices = map[string][]string{
-	"color":           []string{"always", "never", "auto"},
-	"completion":      []string{"bash", "zsh", "fish"},
-	"container-state": []string{stern.RUNNING, stern.WAITING, stern.TERMINATED, stern.ALL_STATES},
-	"output":          []string{"default", "raw", "json", "extjson", "ppextjson"},
-	"timestamps":      []string{"default", "short"},
+	"color":           {"always", "never", "auto"},
+	"completion":      {"bash", "zsh", "fish"},
+	"container-state": {stern.RUNNING, stern.WAITING, stern.TERMINATED, stern.ALL_STATES},
+	"output":          {"default", "raw", "json", "extjson", "ppextjson"},
+	"timestamps":      {"default", "short"},
 }
 
 func runCompletion(shell string, cmd *cobra.Command, out io.Writer) error {


### PR DESCRIPTION
This PR integrates fmt and vet checks in Makefile into golangci-lint. It configures golangci-lint to enable [gofmt](https://golangci-lint.run/usage/linters/#gofmt) and [the default linters, including govet](https://golangci-lint.run/usage/linters/#enabled-by-default).