### PR TITLE
Add log level color keys and handle default

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -499,7 +499,7 @@ func (o *options) generateTemplate() (*template.Template, error) {
 			case "critical":
 				levelColor = color.New(color.FgCyan)
 			default:
-				levelColor = color.New(color.FgWhite)
+				return level
 			}
 			return levelColor.SprintFunc()(level)
 		},

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -486,6 +486,8 @@ func (o *options) generateTemplate() (*template.Template, error) {
 				levelColor = color.New(color.FgBlue)
 			case "warn":
 				levelColor = color.New(color.FgYellow)
+			case "warning":
+				levelColor = color.New(color.FgYellow)
 			case "error":
 				levelColor = color.New(color.FgRed)
 			case "dpanic":
@@ -494,7 +496,10 @@ func (o *options) generateTemplate() (*template.Template, error) {
 				levelColor = color.New(color.FgRed)
 			case "fatal":
 				levelColor = color.New(color.FgCyan)
+			case "critical":
+				levelColor = color.New(color.FgCyan)
 			default:
+				levelColor = color.New(color.FgWhite)
 			}
 			return levelColor.SprintFunc()(level)
 		},


### PR DESCRIPTION
This PR intends to solve issue #263 by handling two more common log-level keys as well as handling the fallback case so that an error is never printed. The two new keys are used in Python's logging facilities.

I didn't find a way to add custom log-level keys as a user, but I think this works well. It would be very appreciated if it didn't cause an error at least.

Test by using stern to print logs from a Python application that emits "warning" and "critical" logs. Preferably also test with an unknown key 
```sh
echo '{"levelname": "invalid key"}' | stern --template='{{with $d := .Message | tryParseJSON}}{{levelColor $d.levelname}}{{end}}{{"\n"}}'
```