### PR TITLE
README.md - make text reference for pod-query match formatting of cli example

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ kubectl krew install stern
 stern pod-query [flags]
 ```
 
-The `pod` query is a regular expression or a Kubernetes resource in the form `<resource>/<name>`.
+The `pod-query` is a regular expression or a Kubernetes resource in the form `<resource>/<name>`.
 
 The query is a regular expression when it is not a Kubernetes resource,
 so you could provide `"web-\w"` to tail `web-backend` and `web-frontend` pods but not `web-123`.


### PR DESCRIPTION
The cli example shows "`pod-query`". The text refers to "`pod` query". These two references should match. This patch does that.