### PR TITLE
Clarify that '=' cannot be omitted in --timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Supported Kubernetes resources are `pod`, `replicationcontroller`, `service`, `d
  `--tail`                    | `-1`                          | The number of lines from the end of the logs to show. Defaults to -1, showing all logs.
  `--template`                |                               | Template to use for log lines, leave empty to use --output flag.
  `--template-file`, `-T`     |                               | Path to template to use for log lines, leave empty to use --output flag. It overrides --template option.
- `--timestamps`, `-t`        |                               | Print timestamps with the specified format. One of 'default' or 'short'. If specified but without value, 'default' is used.
+ `--timestamps`, `-t`        |                               | Print timestamps with the specified format. One of 'default' or 'short' in the form '--timestamps=format' ('=' cannot be omitted). If specified but without value, 'default' is used.
  `--timezone`                | `Local`                       | Set timestamps to specific timezone.
  `--verbosity`               | `0`                           | Number of the log level verbosity
  `--version`, `-v`           | `false`                       | Print the version and exit.

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -414,7 +414,7 @@ func (o *options) AddFlags(fs *pflag.FlagSet) {
 	fs.Int64Var(&o.tail, "tail", o.tail, "The number of lines from the end of the logs to show. Defaults to -1, showing all logs.")
 	fs.StringVar(&o.template, "template", o.template, "Template to use for log lines, leave empty to use --output flag.")
 	fs.StringVarP(&o.templateFile, "template-file", "T", o.templateFile, "Path to template to use for log lines, leave empty to use --output flag. It overrides --template option.")
-	fs.StringVarP(&o.timestamps, "timestamps", "t", o.timestamps, "Print timestamps with the specified format. One of 'default' or 'short'. If specified but without value, 'default' is used.")
+	fs.StringVarP(&o.timestamps, "timestamps", "t", o.timestamps, "Print timestamps with the specified format. One of 'default' or 'short' in the form '--timestamps=format' ('=' cannot be omitted). If specified but without value, 'default' is used.")
 	fs.StringVar(&o.timezone, "timezone", o.timezone, "Set timestamps to specific timezone.")
 	fs.BoolVar(&o.onlyLogLines, "only-log-lines", o.onlyLogLines, "Print only log lines")
 	fs.StringVar(&o.configFilePath, "config", o.configFilePath, "Path to the stern config file")


### PR DESCRIPTION
This commit clarifies that '=' cannot be omitted in --timestamps, as the flag has [a no option default value](https://github.com/spf13/pflag?tab=readme-ov-file#setting-no-option-default-values-for-flags).

Fixes #294
