### PR TITLE
Display different colors for different containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /dist
 /hack/tools/bin
 vendor
+.idea
+.vscode

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Supported Kubernetes resources are `pod`, `replicationcontroller`, `service`, `d
  `--container`, `-c`         | `.*`                          | Container name when multiple containers in pod. (regular expression)
  `--container-state`         | `all`                         | Tail containers with state in running, waiting, terminated, or all. 'all' matches all container states. To specify multiple states, repeat this or set comma-separated value.
  `--context`                 |                               | The name of the kubeconfig context to use
+ `--diff-container`, `-d`    | `false`                       | Display different colors for different containers
  `--ephemeral-containers`    | `true`                        | Include or exclude ephemeral containers.
  `--exclude`, `-e`           | `[]`                          | Log lines to exclude. (regular expression)
  `--exclude-container`, `-E` | `[]`                          | Container name to exclude when multiple containers in pod. (regular expression)

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Supported Kubernetes resources are `pod`, `replicationcontroller`, `service`, `d
  `--container`, `-c`         | `.*`                          | Container name when multiple containers in pod. (regular expression)
  `--container-state`         | `all`                         | Tail containers with state in running, waiting, terminated, or all. 'all' matches all container states. To specify multiple states, repeat this or set comma-separated value.
  `--context`                 |                               | The name of the kubeconfig context to use
- `--diff-container`, `-d`    | `false`                       | Display different colors for different containers
+ `--diff-container`, `-d`    | `false`                       | Display different colors for different containers.
  `--ephemeral-containers`    | `true`                        | Include or exclude ephemeral containers.
  `--exclude`, `-e`           | `[]`                          | Log lines to exclude. (regular expression)
  `--exclude-container`, `-E` | `[]`                          | Container name to exclude when multiple containers in pod. (regular expression)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -86,6 +86,7 @@ type options struct {
 	configFilePath      string
 	showHiddenOptions   bool
 	stdin               bool
+	diffContainer       bool
 
 	client       kubernetes.Interface
 	clientConfig clientcmd.ClientConfig
@@ -318,6 +319,7 @@ func (o *options) sternConfig() (*stern.Config, error) {
 		OnlyLogLines:          o.onlyLogLines,
 		MaxLogRequests:        maxLogRequests,
 		Stdin:                 o.stdin,
+		DiffContainer:         o.diffContainer,
 
 		Out:    o.Out,
 		ErrOut: o.ErrOut,
@@ -435,6 +437,7 @@ func (o *options) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVarP(&o.version, "version", "v", o.version, "Print the version and exit.")
 	fs.BoolVar(&o.showHiddenOptions, "show-hidden-options", o.showHiddenOptions, "Print a list of hidden options.")
 	fs.BoolVar(&o.stdin, "stdin", o.stdin, "Parse logs from stdin. All Kubernetes related flags are ignored when it is set.")
+	fs.BoolVarP(&o.diffContainer, "diff-container", "d", o.diffContainer, "Display different colors for different containers.")
 
 	fs.Lookup("timestamps").NoOptDefVal = "default"
 }

--- a/stern/config.go
+++ b/stern/config.go
@@ -51,6 +51,7 @@ type Config struct {
 	OnlyLogLines          bool
 	MaxLogRequests        int
 	Stdin                 bool
+	DiffContainer         bool
 
 	Out    io.Writer
 	ErrOut io.Writer

--- a/stern/stern.go
+++ b/stern/stern.go
@@ -65,7 +65,7 @@ func Run(ctx context.Context, client kubernetes.Interface, config *Config) error
 		}
 	}
 	newTail := func(t *Target) *Tail {
-		return NewTail(client.CoreV1(), t.Node, t.Namespace, t.Pod, t.Container, config.Template, config.Out, config.ErrOut, newTailOptions())
+		return NewTail(client.CoreV1(), t.Node, t.Namespace, t.Pod, t.Container, config.Template, config.Out, config.ErrOut, newTailOptions(), config.DiffContainer)
 	}
 
 	if config.Stdin {

--- a/stern/tail.go
+++ b/stern/tail.go
@@ -97,21 +97,17 @@ var colorList = [][2]*color.Color{
 }
 
 func determineColor(podName, containerName string, diffContainer bool) (podColor, containerColor *color.Color) {
-	podHash := fnv.New32()
-	_, _ = podHash.Write([]byte(podName))
-	podIdx := podHash.Sum32() % uint32(len(colorList))
-	colors := colorList[podIdx]
-
+	colors := colorList[colorIndex(podName)]
 	if diffContainer {
-		containerHash := fnv.New32()
-		_, _ = containerHash.Write([]byte(containerName))
-		containerIdx := containerHash.Sum32() % uint32(len(colorList))
-		containerColor = colorList[containerIdx][1]
-	} else {
-		containerColor = colors[1]
+		return colors[0], colorList[colorIndex(containerName)][1]
 	}
+	return colors[0], colors[1]
+}
 
-	return colors[0], containerColor
+func colorIndex(name string) uint32 {
+	hash := fnv.New32()
+	_, _ = hash.Write([]byte(name))
+	return hash.Sum32() % uint32(len(colorList))
 }
 
 // Start starts tailing


### PR DESCRIPTION
fixes https://github.com/stern/stern/issues/304
All containers within a pod have the same color by default.
```bash
./stern myapp
```
<img width="854" alt="image" src="https://github.com/stern/stern/assets/40051120/cdea5aa2-a470-4a89-8452-382fd0d77538">

Set `--diff-container` to display different colors for different containers. This is useful when you want to debug logs for multiple containers in the same pod.

```bash
# --diff-container is false by default
./stern myapp --diff-container
```
<img width="833" alt="image" src="https://github.com/stern/stern/assets/40051120/602327b9-480a-42ec-b2d3-d774867c8bed">