### PR TITLE
Add support to configure colors for pods and containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Supported Kubernetes resources are `pod`, `replicationcontroller`, `service`, `d
  `--completion`              |                               | Output stern command-line completion code for the specified shell. Can be 'bash', 'zsh' or 'fish'.
  `--config`                  | `~/.config/stern/config.yaml` | Path to the stern config file
  `--container`, `-c`         | `.*`                          | Container name when multiple containers in pod. (regular expression)
+ `--container-colors`        |                               | Specifies the colors used to highlight container names. Use the same format as --pod-colors. Defaults to the values of --pod-colors if omitted, and must match its length.
  `--container-state`         | `all`                         | Tail containers with state in running, waiting, terminated, or all. 'all' matches all container states. To specify multiple states, repeat this or set comma-separated value.
  `--context`                 |                               | The name of the kubeconfig context to use
  `--diff-container`, `-d`    | `false`                       | Display different colors for different containers.
@@ -94,6 +95,7 @@ Supported Kubernetes resources are `pod`, `replicationcontroller`, `service`, `d
  `--node`                    |                               | Node name to filter on.
  `--only-log-lines`          | `false`                       | Print only log lines
  `--output`, `-o`            | `default`                     | Specify predefined template. Currently support: [default, raw, json, extjson, ppextjson]
+ `--pod-colors`              |                               | Specifies the colors used to highlight pod names. Provide colors as a comma-separated list using SGR (Select Graphic Rendition) sequences, e.g., "91,92,93,94,95,96".
  `--prompt`, `-p`            | `false`                       | Toggle interactive prompt for selecting 'app.kubernetes.io/instance' label values.
  `--selector`, `-l`          |                               | Selector (label query) to filter on. If present, default to ".*" for the pod-query.
  `--show-hidden-options`     | `false`                       | Print a list of hidden options.
@@ -196,6 +198,28 @@ The behavior and the default are different depending on the presence of the `--n
 | not specified | 50      | exits with an error when if it reaches the concurrent limit |
 
 The combination of `--max-log-requests 1` and `--no-follow` will be helpful if you want to show logs in order.
+
+### Customize highlight colors
+You can configure highlight colors for pods and containers in [the config file](#config-file) using a comma-separated list of [SGR (Select Graphic Rendition) sequences](https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters), as shown below. If you omit `container-colors`, the pod colors will be used as container colors as well.
+
+```yaml
+# Green, Yellow, Blue, Magenta, Cyan, White
+pod-colors: "32,33,34,35,36,37"
+
+# Colors with underline (4)
+# If empty, the pod colors will be used as container colors
+container-colors: "32;4,33;4,34;4,35;4,36;4,37;4"
+```
+
+This format enables the use of various attributes, such as underline, background colors, 8-bit colors, and 24-bit colors, if your terminal supports them.
+
+The equivalent flags `--pod-colors` and `--container-colors` are also available. The following command applies [24-bit colors](https://en.wikipedia.org/wiki/ANSI_escape_code#24-bit) using the `--pod-colors` flag.
+
+```bash
+# Monokai theme
+podColors="38;2;255;97;136,38;2;169;220;118,38;2;255;216;102,38;2;120;220;232,38;2;171;157;242"
+stern --pod-colors "$podColors" deploy/app
+```
 
 ## Examples:
 Tail all logs from all namespaces

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -87,6 +87,8 @@ type options struct {
 	showHiddenOptions   bool
 	stdin               bool
 	diffContainer       bool
+	podColors           []string
+	containerColors     []string
 
 	client       kubernetes.Interface
 	clientConfig clientcmd.ClientConfig
@@ -167,6 +169,9 @@ func (o *options) Validate() error {
 
 func (o *options) Run(cmd *cobra.Command) error {
 	if err := o.setVerbosity(); err != nil {
+		return err
+	}
+	if err := o.setColorList(); err != nil {
 		return err
 	}
 
@@ -339,6 +344,13 @@ func (o *options) setVerbosity() error {
 	return nil
 }
 
+func (o *options) setColorList() error {
+	if len(o.podColors) > 0 || len(o.containerColors) > 0 {
+		return stern.SetColorList(o.podColors, o.containerColors)
+	}
+	return nil
+}
+
 // overrideFlagSetDefaultFromConfig overrides the default value of the flagSets
 // from the config file
 func (o *options) overrideFlagSetDefaultFromConfig(fs *pflag.FlagSet) error {
@@ -438,6 +450,8 @@ func (o *options) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.showHiddenOptions, "show-hidden-options", o.showHiddenOptions, "Print a list of hidden options.")
 	fs.BoolVar(&o.stdin, "stdin", o.stdin, "Parse logs from stdin. All Kubernetes related flags are ignored when it is set.")
 	fs.BoolVarP(&o.diffContainer, "diff-container", "d", o.diffContainer, "Display different colors for different containers.")
+	fs.StringSliceVar(&o.podColors, "pod-colors", o.podColors, "Specifies the colors used to highlight pod names. Provide colors as a comma-separated list using SGR (Select Graphic Rendition) sequences, e.g., \"91,92,93,94,95,96\".")
+	fs.StringSliceVar(&o.containerColors, "container-colors", o.containerColors, "Specifies the colors used to highlight container names. Use the same format as --pod-colors. Defaults to the values of --pod-colors if omitted, and must match its length.")
 
 	fs.Lookup("timestamps").NoOptDefVal = "default"
 }

--- a/stern/color.go
+++ b/stern/color.go
@@ -1,0 +1,74 @@
+package stern
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+
+	"github.com/fatih/color"
+)
+
+var colorList = [][2]*color.Color{
+	{color.New(color.FgHiCyan), color.New(color.FgCyan)},
+	{color.New(color.FgHiGreen), color.New(color.FgGreen)},
+	{color.New(color.FgHiMagenta), color.New(color.FgMagenta)},
+	{color.New(color.FgHiYellow), color.New(color.FgYellow)},
+	{color.New(color.FgHiBlue), color.New(color.FgBlue)},
+	{color.New(color.FgHiRed), color.New(color.FgRed)},
+}
+
+func SetColorList(podColors, containerColors []string) error {
+	colors, err := parseColors(podColors, containerColors)
+	if err != nil {
+		return err
+	}
+	colorList = colors
+	return nil
+}
+
+func parseColors(podColors, containerColors []string) ([][2]*color.Color, error) {
+	if len(podColors) == 0 {
+		return nil, errors.New("pod-colors must not be empty")
+	}
+	if len(containerColors) == 0 {
+		// if containerColors is empty, use podColors as containerColors
+		return createColorPairs(podColors, podColors)
+	}
+	if len(containerColors) != len(podColors) {
+		return nil, errors.New("pod-colors and container-colors must have the same length")
+	}
+	return createColorPairs(podColors, containerColors)
+}
+
+func createColorPairs(podColors, containerColors []string) ([][2]*color.Color, error) {
+	colorList := make([][2]*color.Color, 0, len(podColors))
+	for i := 0; i < len(podColors); i++ {
+		podColor, err := sgrSequenceToColor(podColors[i])
+		if err != nil {
+			return nil, err
+		}
+		containerColor, err := sgrSequenceToColor(containerColors[i])
+		if err != nil {
+			return nil, err
+		}
+		colorList = append(colorList, [2]*color.Color{podColor, containerColor})
+	}
+	return colorList, nil
+}
+
+// sgrSequenceToColor converts a string representing SGR sequence
+// separated by ";" into a *color.Color instance.
+// For example, "31;4" means red foreground with underline.
+// https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters
+func sgrSequenceToColor(s string) (*color.Color, error) {
+	parts := strings.Split(s, ";")
+	attrs := make([]color.Attribute, 0, len(parts))
+	for _, part := range parts {
+		attr, err := strconv.ParseInt(strings.TrimSpace(part), 10, 32)
+		if err != nil {
+			return nil, err
+		}
+		attrs = append(attrs, color.Attribute(attr))
+	}
+	return color.New(attrs...), nil
+}

--- a/stern/color_test.go
+++ b/stern/color_test.go
@@ -1,0 +1,106 @@
+package stern
+
+import (
+	"testing"
+
+	"github.com/fatih/color"
+)
+
+func TestParseColors(t *testing.T) {
+	tests := []struct {
+		desc            string
+		podColors       []string
+		containerColors []string
+		want            [][2]*color.Color
+		wantError       bool
+	}{
+		{
+			desc:            "both pod and container colors are specified",
+			podColors:       []string{"91", "92", "93"},
+			containerColors: []string{"31", "32", "33"},
+			want: [][2]*color.Color{
+				{color.New(color.FgHiRed), color.New(color.FgRed)},
+				{color.New(color.FgHiGreen), color.New(color.FgGreen)},
+				{color.New(color.FgHiYellow), color.New(color.FgYellow)},
+			},
+		},
+		{
+			desc:            "only pod colors are specified",
+			podColors:       []string{"91", "92", "93"},
+			containerColors: []string{},
+			want: [][2]*color.Color{
+				{color.New(color.FgHiRed), color.New(color.FgHiRed)},
+				{color.New(color.FgHiGreen), color.New(color.FgHiGreen)},
+				{color.New(color.FgHiYellow), color.New(color.FgHiYellow)},
+			},
+		},
+		{
+			desc:            "multiple attributes",
+			podColors:       []string{"4;91"},
+			containerColors: []string{"38;2;255;97;136"},
+			want: [][2]*color.Color{
+				{
+					color.New(color.Underline, color.FgHiRed),
+					color.New(38, 2, 255, 97, 136), // 24-bit color
+				},
+			},
+		},
+		{
+			desc:            "spaces are ignored",
+			podColors:       []string{"  91 ", "\t92\t"},
+			containerColors: []string{},
+			want: [][2]*color.Color{
+				{color.New(color.FgHiRed), color.New(color.FgHiRed)},
+				{color.New(color.FgHiGreen), color.New(color.FgHiGreen)},
+			},
+		},
+		// error patterns
+		{
+			desc:            "only container colors are specified",
+			podColors:       []string{},
+			containerColors: []string{"31", "32", "33"},
+			wantError:       true,
+		},
+		{
+			desc:            "both pod and container colors are empty",
+			podColors:       []string{},
+			containerColors: []string{},
+			wantError:       true,
+		},
+		{
+			desc:            "invalid color",
+			podColors:       []string{"a"},
+			containerColors: []string{""},
+			wantError:       true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			colorList, err := parseColors(tt.podColors, tt.containerColors)
+
+			if tt.wantError {
+				if err == nil {
+					t.Error("expected err, but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+
+			if len(tt.want) != len(colorList) {
+				t.Fatalf("expected colorList of size %d, but got %d", len(tt.want), len(colorList))
+			}
+
+			for i, wantPair := range tt.want {
+				gotPair := colorList[i]
+				if !wantPair[0].Equals(gotPair[0]) {
+					t.Errorf("colorList[%d][0]: expected %v, but got %v", i, wantPair[0], gotPair[0])
+				}
+				if !wantPair[1].Equals(gotPair[1]) {
+					t.Errorf("colorList[%d][1]: expected %v, but got %v", i, wantPair[1], gotPair[1])
+				}
+			}
+		})
+	}
+}

--- a/stern/tail.go
+++ b/stern/tail.go
@@ -87,15 +87,6 @@ func NewTail(clientset corev1client.CoreV1Interface, nodeName, namespace, podNam
 	}
 }
 
-var colorList = [][2]*color.Color{
-	{color.New(color.FgHiCyan), color.New(color.FgCyan)},
-	{color.New(color.FgHiGreen), color.New(color.FgGreen)},
-	{color.New(color.FgHiMagenta), color.New(color.FgMagenta)},
-	{color.New(color.FgHiYellow), color.New(color.FgYellow)},
-	{color.New(color.FgHiBlue), color.New(color.FgBlue)},
-	{color.New(color.FgHiRed), color.New(color.FgRed)},
-}
-
 func determineColor(podName, containerName string, diffContainer bool) (podColor, containerColor *color.Color) {
 	colors := colorList[colorIndex(podName)]
 	if diffContainer {


### PR DESCRIPTION
Fixes #298

This PR adds support for configuring colors for pods and containers.

```
podColors="38;2;255;97;136,38;2;169;220;118,38;2;255;216;102,38;2;120;220;232,38;2;171;157;242"
dist/stern --pod-colors "$podColors" --tail 1 --only-log-lines deployment/app
```

<img width="1227" alt="image" src="https://github.com/stern/stern/assets/9250296/836a8c77-1120-4bb5-8da6-724bc5677d87">


---

### Customize highlight colors
You can configure highlight colors for pods and containers in [the config file](#config-file) using a comma-separated list of [SGR (Select Graphic Rendition) sequences](https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters), as shown below. If you omit `container-colors`, the pod colors will be used as container colors as well.

```yaml
# Green, Yellow, Blue, Magenta, Cyan, White
pod-colors: "32,33,34,35,36,37"

# Colors with underline (4)
# If empty, the pod colors will be used as container colors
container-colors: "32;4,33;4,34;4,35;4,36;4,37;4"
```

This format enables the use of various attributes, such as underline, background colors, 8-bit colors, and 24-bit colors, if your terminal supports them.

The equivalent flags `--pod-colors` and `--container-colors` are also available. The following command applies [24-bit colors](https://en.wikipedia.org/wiki/ANSI_escape_code#24-bit) using the `--pod-colors` flag.

```bash
# Monokai theme
podColors="38;2;255;97;136,38;2;169;220;118,38;2;255;216;102,38;2;120;220;232,38;2;171;157;242"
stern --pod-colors "$podColors" deploy/app
```
