### PR TITLE
Allow `levelColor` template function to parse numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ functions](https://golang.org/pkg/text/template/#hdr-Functions)):
 | `toRFC3339Nano` | `object`              | Parse timestamp (string, int, json.Number) and output it using RFC3339Nano format |
 | `toTimestamp`   | `object, string [, string]` | Parse timestamp (string, int, json.Number) and output it using the given layout in the timezone that is optionally given (defaults to UTC). |
 | `levelColor`    | `string`              | Print log level using appropriate color                                           |
+| `bunyanLevelColor`    | `string`        | Print [bunyan](https://github.com/trentm/node-bunyan) numeric log level using appropriate color |
 | `colorBlack`    | `string`              | Print text using black color                                                      |
 | `colorRed`      | `string`              | Print text using red color                                                        |
 | `colorGreen`    | `string`              | Print text using green color                                                      |

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -610,31 +610,36 @@ func (o *options) generateTemplate() (*template.Template, error) {
 		"colorMagenta": color.MagentaString,
 		"colorCyan":    color.CyanString,
 		"colorWhite":   color.WhiteString,
-		"levelColor": func(level string) string {
-			var levelColor *color.Color
-			switch strings.ToLower(level) {
-			case "debug":
-				levelColor = color.New(color.FgMagenta)
-			case "info":
-				levelColor = color.New(color.FgBlue)
-			case "warn":
-				levelColor = color.New(color.FgYellow)
-			case "warning":
-				levelColor = color.New(color.FgYellow)
-			case "error":
-				levelColor = color.New(color.FgRed)
-			case "dpanic":
-				levelColor = color.New(color.FgRed)
-			case "panic":
-				levelColor = color.New(color.FgRed)
-			case "fatal":
-				levelColor = color.New(color.FgCyan)
-			case "critical":
-				levelColor = color.New(color.FgCyan)
+		"levelColor": func(value any) string {
+			switch level := value.(type) {
+			case string:
+				var levelColor *color.Color
+				switch strings.ToLower(level) {
+				case "debug":
+					levelColor = color.New(color.FgMagenta)
+				case "info":
+					levelColor = color.New(color.FgBlue)
+				case "warn":
+					levelColor = color.New(color.FgYellow)
+				case "warning":
+					levelColor = color.New(color.FgYellow)
+				case "error":
+					levelColor = color.New(color.FgRed)
+				case "dpanic":
+					levelColor = color.New(color.FgRed)
+				case "panic":
+					levelColor = color.New(color.FgRed)
+				case "fatal":
+					levelColor = color.New(color.FgCyan)
+				case "critical":
+					levelColor = color.New(color.FgCyan)
+				default:
+					return level
+				}
+				return levelColor.SprintFunc()(level)
 			default:
-				return level
+				return ""
 			}
-			return levelColor.SprintFunc()(level)
 		},
 		"bunyanLevelColor": func(value any) string {
 			var lv int64

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -636,6 +636,41 @@ func (o *options) generateTemplate() (*template.Template, error) {
 			}
 			return levelColor.SprintFunc()(level)
 		},
+		"bunyanLevelColor": func(value any) string {
+			var lv int64
+			var err error
+
+			switch level := value.(type) {
+			// tryParseJSON yields json.Number
+			case json.Number:
+				lv, err = level.Int64()
+				if err != nil {
+					return ""
+				}
+			// parseJSON yields float64
+			case float64:
+				lv = int64(level)
+			default:
+				return ""
+			}
+
+			var levelColor *color.Color
+			switch {
+			case lv < 30:
+				levelColor = color.New(color.FgMagenta)
+			case lv < 40:
+				levelColor = color.New(color.FgBlue)
+			case lv < 50:
+				levelColor = color.New(color.FgYellow)
+			case lv < 60:
+				levelColor = color.New(color.FgRed)
+			case lv < 100:
+				levelColor = color.New(color.FgCyan)
+			default:
+				return strconv.FormatInt(lv, 10)
+			}
+			return levelColor.SprintFunc()(lv)
+		},
 	}
 	template, err := template.New("log").Funcs(funs).Parse(t)
 	if err != nil {


### PR DESCRIPTION
This fixes #320

This PR extends the functionality of the template function `levelColor` to also support numeric values. Try it out with
```
for l in 10 20 30 40 50 60 70 \"debug\" \"info\" \"warn\" \"error\" \"fatal\"; do echo '{"level": '$l', "msg": "A message"}'; done | stern --stdin --template='{{with $d := .Message | parseJSON}}[{{levelColor $d.level}}] {{$d.msg}}{{end}}{{"\n"}}'
```

In case it cannot parse the value as a string or number it currently falls back to returning an empty string without an error. I think this is quite nice as it allows for things like this `{{or (colorLevel $d.level) "N/A"}}` if the level is missing completely.  It is however a behavior change.

Furthermore, it can be debated whether the levels I've chosen make the most sense. They are set according to what [bunyan](https://github.com/trentm/node-bunyan?tab=readme-ov-file#levels) and [pino](https://github.com/pinojs/pino/blob/main/docs/api.md#loggerlevels-object) uses whereas [log4j](https://logging.apache.org/log4j/2.x/manual/customloglevels.html) use levels in the 100s. A flag to switch between the two styles perhaps?
