### PR TITLE
WIP: --same-prefix-color: same color pods with same prefix

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -89,6 +89,7 @@ type options struct {
 	diffContainer       bool
 	podColors           []string
 	containerColors     []string
+	samePrefixColor     bool
 
 	client       kubernetes.Interface
 	clientConfig clientcmd.ClientConfig
@@ -322,6 +323,7 @@ func (o *options) sternConfig() (*stern.Config, error) {
 		MaxLogRequests:        maxLogRequests,
 		Stdin:                 o.stdin,
 		DiffContainer:         o.diffContainer,
+		SamePrefixColor:       o.samePrefixColor,
 
 		Out:    o.Out,
 		ErrOut: o.ErrOut,
@@ -449,6 +451,7 @@ func (o *options) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVarP(&o.diffContainer, "diff-container", "d", o.diffContainer, "Display different colors for different containers.")
 	fs.StringSliceVar(&o.podColors, "pod-colors", o.podColors, "Specifies the colors used to highlight pod names. Provide colors as a comma-separated list using SGR (Select Graphic Rendition) sequences, e.g., \"91,92,93,94,95,96\".")
 	fs.StringSliceVar(&o.containerColors, "container-colors", o.containerColors, "Specifies the colors used to highlight container names. Use the same format as --pod-colors. Defaults to the values of --pod-colors if omitted, and must match its length.")
+	fs.BoolVar(&o.samePrefixColor, "same-prefix-color", o.samePrefixColor, "Color containers with the same prefix the same")
 
 	fs.Lookup("timestamps").NoOptDefVal = "default"
 }

--- a/stern/config.go
+++ b/stern/config.go
@@ -52,6 +52,7 @@ type Config struct {
 	MaxLogRequests        int
 	Stdin                 bool
 	DiffContainer         bool
+	SamePrefixColor       bool
 
 	Out    io.Writer
 	ErrOut io.Writer

--- a/stern/stern.go
+++ b/stern/stern.go
@@ -62,6 +62,7 @@ func Run(ctx context.Context, client kubernetes.Interface, config *Config) error
 			TailLines:       config.TailLines,
 			Follow:          config.Follow,
 			OnlyLogLines:    config.OnlyLogLines,
+			SamePrefixColor: config.SamePrefixColor,
 		}
 	}
 	newTail := func(t *Target) *Tail {

--- a/stern/tail_utils.go
+++ b/stern/tail_utils.go
@@ -50,6 +50,8 @@ type TailOptions struct {
 
 	// regexp for highlighting the matched string
 	reHightlight *regexp.Regexp
+
+	SamePrefixColor bool // New option to color containers with the same prefix the same
 }
 
 func (o TailOptions) IsExclude(msg string) bool {


### PR DESCRIPTION
First shot (please, suggest a better approach) at 2 issues that I hit.

1) --same-prefix-color -- use the same color for pods that have the same name prefix such as 'api-1' and 'api-2'

2)  Prevent collisions of color assignment if there are enough colors  "query" and "reader"

I have pods from different stateful sets that I would like to color the same, but different for each SS:

```
kubectl get pods
NAME       READY   STATUS    RESTARTS   AGE
api-0      1/1     Running   0          4h46m
api-1      1/1     Running   0          114m
api-2      1/1     Running   0          4h49m
ingest-0   1/1     Running   0          4h47m
ingest-1   1/1     Running   0          4h49m
ingest-2   1/1     Running   0          4h52m
query-0    1/1     Running   0          4h47m
query-1    1/1     Running   0          4h48m
query-2    1/1     Running   0          160m
reader-0   1/1     Running   0          4h46m
reader-1   1/1     Running   0          4h47m
reader-2   1/1     Running   0          4h49m
worker-0   1/1     Running   0          4h43m
worker-1   1/1     Running   0          4h44m
worker-2   1/1     Running   0          4h46m
writer-0   1/1     Running   0          4h48m
writer-1   1/1     Running   0          160m
writer-2   1/1     Running   0          114m
```

with these changes I can do:

```
/stern.bin "(api|ingest|query|reader|worker|writer)-.*" --same-prefix-color --pod-colors "38;2;255;97;136,38;2;169;220;118,38;2;255;216;102,38;2;120;220;232,38;2;171;157;242" --tail 10
```

and get the desired effect 

Please, advise what changes would make this PR or it's part acceptable for the project.

Thank you!