### PR TITLE
Implement JSON pretty print

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,15 @@ Output using a custom template that tries to parse JSON or fallbacks to raw form
 stern --template='{{.PodName}}/{{.ContainerName}} {{ with $msg := .Message | tryParseJSON }}[{{ colorGreen (toRFC3339Nano $msg.ts) }}] {{ levelColor $msg.level }} ({{ colorCyan $msg.caller }}) {{ $msg.msg }}{{ else }} {{ .Message }} {{ end }}{{"\n"}}' backend
 ```
 
+Pretty print JSON (if it is JSON) and output it:
+
+```
+# Will try to parse .Message as JSON and pretty print it, if not json will output as is
+stern --template='{{ .Message | prettyJSON }}{{"\n"}}' backend
+# Or with parsed json, will drop non-json logs because of `with`
+stern --template='{{ with $msg := .Message | tryParseJSON }}{{ prettyJSON $msg }}{{"\n"}}{{end}}' backend
+```
+
 Load custom template from file:
 
 ```

--- a/README.md
+++ b/README.md
@@ -157,27 +157,27 @@ will receive the following struct:
 The following functions are available within the template (besides the [builtin
 functions](https://golang.org/pkg/text/template/#hdr-Functions)):
 
-| func            | arguments             | description                                                                       |
-|-----------------|-----------------------|-----------------------------------------------------------------------------------|
-| `json`          | `object`              | Marshal the object and output it as a json text                                   |
-| `color`         | `color.Color, string` | Wrap the text in color (.ContainerColor and .PodColor provided)                   |
-| `parseJSON`     | `string`              | Parse string as JSON                                                              |
-| `tryParseJSON`  | `string`              | Attempt to parse string as JSON, return nil on failure                             |
-| `extractJSONParts`    | `string, ...string` | Parse string as JSON and concatenate the given keys.                          |
-| `tryExtractJSONParts` | `string, ...string` | Attempt to parse string as JSON and concatenate the given keys. , return text on failure |
-| `toRFC3339Nano` | `object`              | Parse timestamp (string, int, json.Number) and output it using RFC3339Nano format |
-| `toTimestamp`   | `object, string [, string]` | Parse timestamp (string, int, json.Number) and output it using the given layout in the timezone that is optionally given (defaults to UTC). |
-| `levelColor`    | `string`              | Print log level using appropriate color                                           |
-| `bunyanLevelColor`    | `string`        | Print [bunyan](https://github.com/trentm/node-bunyan) numeric log level using appropriate color |
-| `colorBlack`    | `string`              | Print text using black color                                                      |
-| `colorRed`      | `string`              | Print text using red color                                                        |
-| `colorGreen`    | `string`              | Print text using green color                                                      |
-| `colorYellow`   | `string`              | Print text using yellow color                                                     |
-| `colorBlue`     | `string`              | Print text using blue color                                                       |
-| `colorMagenta`  | `string`              | Print text using magenta color                                                    |
-| `colorCyan`     | `string`              | Print text using cyan color                                                       |
-| `colorWhite`    | `string`              | Print text using white color                                                      |
-
+| func                  | arguments                   | description                                                                                                                                 |
+|-----------------------|-----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
+| `json`                | `object`                    | Marshal the object and output it as a json text                                                                                             |
+| `color`               | `color.Color, string`       | Wrap the text in color (.ContainerColor and .PodColor provided)                                                                             |
+| `parseJSON`           | `string`                    | Parse string as JSON                                                                                                                        |
+| `tryParseJSON`        | `string`                    | Attempt to parse string as JSON, return nil on failure                                                                                      |
+| `extractJSONParts`    | `string, ...string`         | Parse string as JSON and concatenate the given keys.                                                                                        |
+| `tryExtractJSONParts` | `string, ...string`         | Attempt to parse string as JSON and concatenate the given keys. , return text on failure                                                    |
+| `prettyJSON`          | `string`                    | Parse input and emit it as pretty printed JSON, if parse fails output string as is.                                                         |
+| `toRFC3339Nano`       | `object`                    | Parse timestamp (string, int, json.Number) and output it using RFC3339Nano format                                                           |
+| `toTimestamp`         | `object, string [, string]` | Parse timestamp (string, int, json.Number) and output it using the given layout in the timezone that is optionally given (defaults to UTC). |
+| `levelColor`          | `string`                    | Print log level using appropriate color                                                                                                     |
+| `bunyanLevelColor`    | `string`                    | Print [bunyan](https://github.com/trentm/node-bunyan) numeric log level using appropriate color                                             |
+| `colorBlack`          | `string`                    | Print text using black color                                                                                                                |
+| `colorRed`            | `string`                    | Print text using red color                                                                                                                  |
+| `colorGreen`          | `string`                    | Print text using green color                                                                                                                |
+| `colorYellow`         | `string`                    | Print text using yellow color                                                                                                               |
+| `colorBlue`           | `string`                    | Print text using blue color                                                                                                                 |
+| `colorMagenta`        | `string`                    | Print text using magenta color                                                                                                              |
+| `colorCyan`           | `string`                    | Print text using cyan color                                                                                                                 |
+| `colorWhite`          | `string`                    | Print text using white color                                                                                                                |
 
 ### Log level verbosity
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ functions](https://golang.org/pkg/text/template/#hdr-Functions)):
 | `tryParseJSON`        | `string`                    | Attempt to parse string as JSON, return nil on failure                                                                                      |
 | `extractJSONParts`    | `string, ...string`         | Parse string as JSON and concatenate the given keys.                                                                                        |
 | `tryExtractJSONParts` | `string, ...string`         | Attempt to parse string as JSON and concatenate the given keys. , return text on failure                                                    |
-| `prettyJSON`          | `string`                    | Parse input and emit it as pretty printed JSON, if parse fails output string as is.                                                         |
+| `prettyJSON`          | `any`                       | Parse input and emit it as pretty printed JSON, if parse fails output string as is.                                                         |
 | `toRFC3339Nano`       | `object`                    | Parse timestamp (string, int, json.Number) and output it using RFC3339Nano format                                                           |
 | `toTimestamp`         | `object, string [, string]` | Parse timestamp (string, int, json.Number) and output it using the given layout in the timezone that is optionally given (defaults to UTC). |
 | `levelColor`          | `string`                    | Print log level using appropriate color                                                                                                     |

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -520,12 +520,24 @@ func (o *options) generateTemplate() (*template.Template, error) {
 	}
 
 	funs := map[string]interface{}{
-		"json": func(in interface{}) (string, error) {
-			b, err := json.Marshal(in)
-			if err != nil {
-				return "", err
+		"json": func(in interface{}, pretty ...bool) (string, error) {
+			prettyPrint := false
+			if len(pretty) > 0 {
+				prettyPrint = pretty[0]
 			}
-			return string(b), nil
+			if prettyPrint {
+				b, err := json.MarshalIndent(in, "", "  ")
+				if err != nil {
+					return "", err
+				}
+				return string(b), nil
+			} else {
+				b, err := json.Marshal(in)
+				if err != nil {
+					return "", err
+				}
+				return string(b), nil
+			}
 		},
 		"tryParseJSON": func(text string) map[string]interface{} {
 			decoder := json.NewDecoder(strings.NewReader(text))

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -575,6 +575,18 @@ func (o *options) generateTemplate() (*template.Template, error) {
 			}
 			return strings.TrimSuffix(string(b), "\n"), nil
 		},
+		"prettyJSON": func(text string) (string, error) {
+			// Parse JSON string and pretty print it
+			obj := make(map[string]interface{})
+			if err := json.Unmarshal([]byte(text), &obj); err != nil {
+				return "", err
+			}
+			if prettyBytes, err := json.MarshalIndent(obj, "", "  "); err != nil {
+				return "", err
+			} else {
+				return string(prettyBytes), nil
+			}
+		},
 		"toRFC3339Nano": func(ts any) string {
 			return toTime(ts).Format(time.RFC3339Nano)
 		},


### PR DESCRIPTION
Following what has been suggested in https://github.com/stern/stern/issues/323 I tried to implement a `prettyJSON` template function and a `pretty` flag for existing `json`.

My go skills are near to zero, so forgive me if I wrote bad code. I'm open to suggestions 😉 

Basic usage:

```
# Output formatted json from object
{{- with $msg := .Message | tryParseJSON -}}
{{- json $msg true }}{{ "\n" }}
{{- end -}}
# Output formatted JSON from string
{{ .Message | prettyJSON }}
```
