### PR TITLE
Make `--condition=Ready=false` match running jobs

### DIFF
--- a/stern/target.go
+++ b/stern/target.go
@@ -83,7 +83,7 @@ func (f *targetFilter) visit(pod *corev1.Pod, visitor func(t *Target, conditionF
 	// filter by condition
 	conditionFound := true
 	if f.c.condition != (Condition{}) {
-		conditionFound = f.c.condition.Match(pod.Status.Conditions)
+		conditionFound = f.c.condition.Match(pod)
 	}
 
 	// filter by container statuses


### PR DESCRIPTION
This PR adds a special handling for `--condition=Ready=false` for jobs.

Jobs otherwise reports as `Ready=true` as soon as they are started, meaning no jobs would ever be part of the `--condition=Ready=false` list, thus making it very difficult to track progress of normal pods alongside jobs.

This PR starts from the assumption that jobs are not ready until they are completed. Thus, if the job is running, it is not ready.

What do you think?
