### PR TITLE
338: fix: move highlighting after formatting

### DIFF
--- a/stern/file_tail.go
+++ b/stern/file_tail.go
@@ -57,7 +57,7 @@ func (t *FileTail) ConsumeReader(reader *bufio.Reader) error {
 }
 
 // Print prints a color coded log message
-func (t *FileTail) Print(msg string) {
+func (t *FileTail) Print(msg string, withHighlight bool) {
 	vm := Log{
 		Message:        msg,
 		NodeName:       "",
@@ -74,6 +74,10 @@ func (t *FileTail) Print(msg string) {
 		return
 	}
 
+	if withHighlight {
+		fmt.Fprint(t.out, t.Options.HighlightMatchedString(buf.String()))
+		return
+	}
 	fmt.Fprint(t.out, buf.String())
 }
 
@@ -84,6 +88,5 @@ func (t *FileTail) consumeLine(line string) {
 		return
 	}
 
-	msg := t.Options.HighlightMatchedString(content)
-	t.Print(msg)
+	t.Print(content, true)
 }


### PR DESCRIPTION
Closes issue: [338](https://github.com/stern/stern/issues/338)

Highlighting was moved after templating 