### PR TITLE
Add support for labels & annotations in templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,13 +147,15 @@ It accepts a custom template through the `--template` flag, which will be
 compiled to a Go template and then used for every log message. This Go template
 will receive the following struct:
 
-| property        | type   | description                                 |
-|-----------------|--------|---------------------------------------------|
-| `Message`       | string | The log message itself                      |
-| `NodeName`      | string | The node name where the pod is scheduled on |
-| `Namespace`     | string | The namespace of the pod                    |
-| `PodName`       | string | The name of the pod                         |
-| `ContainerName` | string | The name of the container                   |
+| property        | type              | description                                 |
+|-----------------|-------------------|---------------------------------------------|
+| `Message`       | string            | The log message itself                      |
+| `NodeName`      | string            | The node name where the pod is scheduled on |
+| `Namespace`     | string            | The namespace of the pod                    |
+| `PodName`       | string            | The name of the pod                         |
+| `ContainerName` | string            | The name of the container                   |
+| `Labels`        | map[string]string | The labels of the pod                       |
+| `Annotations`   | map[string]string | The annotations of the pod                  |
 
 The following functions are available within the template (besides the [builtin
 functions](https://golang.org/pkg/text/template/#hdr-Functions)):

--- a/stern/stern.go
+++ b/stern/stern.go
@@ -66,7 +66,15 @@ func Run(ctx context.Context, client kubernetes.Interface, config *Config) error
 		}
 	}
 	newTail := func(t *Target) *Tail {
-		return NewTail(client.CoreV1(), t.Node, t.Namespace, t.Pod, t.Container, config.Template, config.Out, config.ErrOut, newTailOptions(), config.DiffContainer)
+		// Get pod labels and annotations
+		pod, err := client.CoreV1().Pods(t.Namespace).Get(ctx, t.Pod, metav1.GetOptions{})
+		labels := map[string]string{}
+		annotations := map[string]string{}
+		if err == nil {
+			labels = pod.Labels
+			annotations = pod.Annotations
+		}
+		return NewTail(client.CoreV1(), t.Node, t.Namespace, t.Pod, t.Container, labels, annotations, config.Template, config.Out, config.ErrOut, newTailOptions(), config.DiffContainer)
 	}
 
 	if config.Stdin {

--- a/stern/stern.go
+++ b/stern/stern.go
@@ -66,15 +66,7 @@ func Run(ctx context.Context, client kubernetes.Interface, config *Config) error
 		}
 	}
 	newTail := func(t *Target) *Tail {
-		// Get pod labels and annotations
-		pod, err := client.CoreV1().Pods(t.Namespace).Get(ctx, t.Pod, metav1.GetOptions{})
-		labels := map[string]string{}
-		annotations := map[string]string{}
-		if err == nil {
-			labels = pod.Labels
-			annotations = pod.Annotations
-		}
-		return NewTail(client.CoreV1(), t.Node, t.Namespace, t.Pod, t.Container, labels, annotations, config.Template, config.Out, config.ErrOut, newTailOptions(), config.DiffContainer)
+		return NewTail(client.CoreV1(), t.Pod, t.Container, config.Template, config.Out, config.ErrOut, newTailOptions(), config.DiffContainer)
 	}
 
 	if config.Stdin {

--- a/stern/tail.go
+++ b/stern/tail.go
@@ -47,6 +47,8 @@ type Tail struct {
 	Namespace      string
 	PodName        string
 	ContainerName  string
+	Labels         map[string]string
+	Annotations    map[string]string
 	Options        *TailOptions
 	closed         chan struct{}
 	podColor       *color.Color
@@ -67,7 +69,7 @@ type ResumeRequest struct {
 }
 
 // NewTail returns a new tail for a Kubernetes container inside a pod
-func NewTail(clientset corev1client.CoreV1Interface, nodeName, namespace, podName, containerName string, tmpl *template.Template, out, errOut io.Writer, options *TailOptions, diffContainer bool) *Tail {
+func NewTail(clientset corev1client.CoreV1Interface, nodeName, namespace, podName, containerName string, labels map[string]string, annotations map[string]string, tmpl *template.Template, out, errOut io.Writer, options *TailOptions, diffContainer bool) *Tail {
 	podColor, containerColor := determineColor(podName, containerName, diffContainer)
 
 	return &Tail{
@@ -76,6 +78,8 @@ func NewTail(clientset corev1client.CoreV1Interface, nodeName, namespace, podNam
 		Namespace:      namespace,
 		PodName:        podName,
 		ContainerName:  containerName,
+		Labels:         labels,
+		Annotations:    annotations,
 		Options:        options,
 		closed:         make(chan struct{}),
 		tmpl:           tmpl,
@@ -208,6 +212,8 @@ func (t *Tail) Print(msg string) {
 		Namespace:      t.Namespace,
 		PodName:        t.PodName,
 		ContainerName:  t.ContainerName,
+		Labels:         t.Labels,
+		Annotations:    t.Annotations,
 		PodColor:       t.podColor,
 		ContainerColor: t.containerColor,
 	}

--- a/stern/tail.go
+++ b/stern/tail.go
@@ -43,12 +43,9 @@ const TimestampFormatShort = "01-02 15:04:05"
 type Tail struct {
 	clientset corev1client.CoreV1Interface
 
-	NodeName       string
-	Namespace      string
-	PodName        string
-	ContainerName  string
-	Labels         map[string]string
-	Annotations    map[string]string
+	Pod           *corev1.Pod
+	ContainerName string
+
 	Options        *TailOptions
 	closed         chan struct{}
 	podColor       *color.Color
@@ -69,17 +66,13 @@ type ResumeRequest struct {
 }
 
 // NewTail returns a new tail for a Kubernetes container inside a pod
-func NewTail(clientset corev1client.CoreV1Interface, nodeName, namespace, podName, containerName string, labels map[string]string, annotations map[string]string, tmpl *template.Template, out, errOut io.Writer, options *TailOptions, diffContainer bool) *Tail {
-	podColor, containerColor := determineColor(podName, containerName, diffContainer)
+func NewTail(clientset corev1client.CoreV1Interface, pod *corev1.Pod, containerName string, tmpl *template.Template, out, errOut io.Writer, options *TailOptions, diffContainer bool) *Tail {
+	podColor, containerColor := determineColor(pod.Name, containerName, diffContainer)
 
 	return &Tail{
 		clientset:      clientset,
-		NodeName:       nodeName,
-		Namespace:      namespace,
-		PodName:        podName,
+		Pod:            pod,
 		ContainerName:  containerName,
-		Labels:         labels,
-		Annotations:    annotations,
 		Options:        options,
 		closed:         make(chan struct{}),
 		tmpl:           tmpl,
@@ -115,7 +108,7 @@ func (t *Tail) Start(ctx context.Context) error {
 
 	t.printStarting()
 
-	req := t.clientset.Pods(t.Namespace).GetLogs(t.PodName, &corev1.PodLogOptions{
+	req := t.clientset.Pods(t.Pod.Namespace).GetLogs(t.Pod.Name, &corev1.PodLogOptions{
 		Follow:       t.Options.Follow,
 		Timestamps:   true,
 		Container:    t.ContainerName,
@@ -159,9 +152,9 @@ func (t *Tail) printStarting() {
 		p := t.podColor.SprintFunc()
 		c := t.containerColor.SprintFunc()
 		if t.Options.Namespace {
-			fmt.Fprintf(t.errOut, "%s %s %s › %s\n", g("+"), p(t.Namespace), p(t.PodName), c(t.ContainerName))
+			fmt.Fprintf(t.errOut, "%s %s %s › %s\n", g("+"), p(t.Pod.Namespace), p(t.Pod.Name), c(t.ContainerName))
 		} else {
-			fmt.Fprintf(t.errOut, "%s %s › %s\n", g("+"), p(t.PodName), c(t.ContainerName))
+			fmt.Fprintf(t.errOut, "%s %s › %s\n", g("+"), p(t.Pod.Name), c(t.ContainerName))
 		}
 	}
 }
@@ -172,9 +165,9 @@ func (t *Tail) printStopping() {
 		p := t.podColor.SprintFunc()
 		c := t.containerColor.SprintFunc()
 		if t.Options.Namespace {
-			fmt.Fprintf(t.errOut, "%s %s %s › %s\n", r("-"), p(t.Namespace), p(t.PodName), c(t.ContainerName))
+			fmt.Fprintf(t.errOut, "%s %s %s › %s\n", r("-"), p(t.Pod.Namespace), p(t.Pod.Name), c(t.ContainerName))
 		} else {
-			fmt.Fprintf(t.errOut, "%s %s › %s\n", r("-"), p(t.PodName), c(t.ContainerName))
+			fmt.Fprintf(t.errOut, "%s %s › %s\n", r("-"), p(t.Pod.Name), c(t.ContainerName))
 		}
 	}
 }
@@ -208,12 +201,12 @@ func (t *Tail) ConsumeRequest(ctx context.Context, request rest.ResponseWrapper)
 func (t *Tail) Print(msg string) {
 	vm := Log{
 		Message:        msg,
-		NodeName:       t.NodeName,
-		Namespace:      t.Namespace,
-		PodName:        t.PodName,
+		NodeName:       t.Pod.Spec.NodeName,
+		Namespace:      t.Pod.Namespace,
+		PodName:        t.Pod.Name,
 		ContainerName:  t.ContainerName,
-		Labels:         t.Labels,
-		Annotations:    t.Annotations,
+		Labels:         t.Pod.Labels,
+		Annotations:    t.Pod.Annotations,
 		PodColor:       t.podColor,
 		ContainerColor: t.containerColor,
 	}

--- a/stern/tail_test.go
+++ b/stern/tail_test.go
@@ -103,7 +103,7 @@ line 4 (my-node/my-namespace/my-pod/my-container)
 	for i, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			out := new(bytes.Buffer)
-			tail := NewTail(clientset.CoreV1(), "my-node", "my-namespace", "my-pod", "my-container", tmpl, out, io.Discard, &TailOptions{}, false)
+			tail := NewTail(clientset.CoreV1(), "my-node", "my-namespace", "my-pod", "my-container", map[string]string{}, map[string]string{}, tmpl, out, io.Discard, &TailOptions{}, false)
 			tail.resumeRequest = tt.resumeReq
 			if err := tail.ConsumeRequest(context.TODO(), &responseWrapperMock{data: bytes.NewBufferString(logLines)}); err != nil {
 				t.Fatalf("%d: unexpected err %v", i, err)
@@ -162,7 +162,7 @@ func TestPrintStarting(t *testing.T) {
 	clientset := fake.NewSimpleClientset()
 	for i, tt := range tests {
 		errOut := new(bytes.Buffer)
-		tail := NewTail(clientset.CoreV1(), "my-node", "my-namespace", "my-pod", "my-container", nil, io.Discard, errOut, tt.options, false)
+		tail := NewTail(clientset.CoreV1(), "my-node", "my-namespace", "my-pod", "my-container", map[string]string{}, map[string]string{}, nil, io.Discard, errOut, tt.options, false)
 		tail.printStarting()
 
 		if !bytes.Equal(tt.expected, errOut.Bytes()) {
@@ -204,7 +204,7 @@ func TestPrintStopping(t *testing.T) {
 	clientset := fake.NewSimpleClientset()
 	for i, tt := range tests {
 		errOut := new(bytes.Buffer)
-		tail := NewTail(clientset.CoreV1(), "my-node", "my-namespace", "my-pod", "my-container", nil, io.Discard, errOut, tt.options, false)
+		tail := NewTail(clientset.CoreV1(), "my-node", "my-namespace", "my-pod", "my-container", map[string]string{}, map[string]string{}, nil, io.Discard, errOut, tt.options, false)
 		tail.printStopping()
 
 		if !bytes.Equal(tt.expected, errOut.Bytes()) {

--- a/stern/tail_utils.go
+++ b/stern/tail_utils.go
@@ -29,6 +29,12 @@ type Log struct {
 	// ContainerName of the container
 	ContainerName string `json:"containerName"`
 
+	// Labels of the pod
+	Labels map[string]string `json:"labels"`
+
+	// Annotations of the pod
+	Annotations map[string]string `json:"annotations"`
+
 	PodColor       *color.Color `json:"-"`
 	ContainerColor *color.Color `json:"-"`
 }

--- a/stern/target.go
+++ b/stern/target.go
@@ -25,15 +25,13 @@ import (
 
 // Target is a target to watch
 type Target struct {
-	Node      string
-	Namespace string
-	Pod       string
+	Pod       *corev1.Pod
 	Container string
 }
 
 // GetID returns the ID of the object
 func (t *Target) GetID() string {
-	return fmt.Sprintf("%s-%s-%s", t.Namespace, t.Pod, t.Container)
+	return fmt.Sprintf("%s-%s-%s", t.Pod.Namespace, t.Pod.Name, t.Container)
 }
 
 // targetState holds a last shown container ID
@@ -112,9 +110,7 @@ OUTER:
 		}
 
 		t := &Target{
-			Node:      pod.Spec.NodeName,
-			Namespace: pod.Namespace,
-			Pod:       pod.Name,
+			Pod:       pod,
 			Container: c.Name,
 		}
 


### PR DESCRIPTION
Fixes #335 

This is two commits, the first is the minimum needed to support labels & annotations in templates. The second avoids the re-lookup of a pod to get annotations and labels by passing around `Pod` inside `Target`. This should also make it easier to add more fields in templates later as the entire pod is available when `Log` is created.