### PR TITLE
Fix asdf installation typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ go install github.com/stern/stern@latest
 
 If you use [asdf](https://asdf-vm.com/), you can install like this:
 ```
-asdf plugin-add stern
+asdf plugin add stern
 asdf install stern latest
 ```
 


### PR DESCRIPTION
Before
```bash
→ asdf plugin-add stern
invalid command provided: plugin-add

version: v0.18.0 (revision 2114f1e)
...
```
After
```bash
→ asdf plugin add stern
→ asdf plugin list
stern
```