### PR TITLE
Fix 'no entry for key "COMMIT_AUTHOR_NAME"' in the release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,9 @@ jobs:
       run: make release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        COMMIT_AUTHOR_NAME: ${{ vars.COMMIT_AUTHOR_NAME }}
+        COMMIT_AUTHOR_EMAIL: ${{ vars.COMMIT_AUTHOR_EMAIL }}
+        COMMIT_AUTHOR_TOKEN: ${{ secrets.COMMIT_AUTHOR_TOKEN }}
     - name: Update new version in krew-index
       uses: rajatjindal/krew-release-bot@v0.0.47
       with:


### PR DESCRIPTION
This PR fixes 'no entry for key "COMMIT_AUTHOR_NAME"' error in the release workflow. 

https://github.com/stern/stern/actions/runs/19066272470/job/54457598177#step:6:93

## REF

- #354 