### PR TITLE
fix: don't stop following logs from pods when receiving EOF

### DIFF
--- a/stern/stern.go
+++ b/stern/stern.go
@@ -17,6 +17,7 @@ package stern
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"regexp"
 	"strings"
@@ -156,6 +157,16 @@ func Run(ctx context.Context, client kubernetes.Interface, config *Config) error
 			tail.Close()
 			if err == nil {
 				return
+			}
+			if err == io.EOF {
+				// In most cases, EOF signals that the container has terminated.
+				// (and is no longer producting logs).
+				// However, long-running connections might also be closed gracefully by the API server
+				// (or a load balancer in between). Thus, we check whether the target is still active
+				// before stopping tailing logs.
+				if filter.isActive(target) {
+					continue
+				}
 			}
 			if !filter.isActive(target) {
 				fmt.Fprintf(config.ErrOut, "failed to tail: %v\n", err)

--- a/stern/stern.go
+++ b/stern/stern.go
@@ -171,7 +171,11 @@ func Run(ctx context.Context, client kubernetes.Interface, config *Config) error
 				// To ensure we retry fetching the pod logs in that case, we wait a bit before exiting.
 				// If we receive the "pod deleted" event during this time, then the
 				// target will be removed from the filter (see next check) and we won't retry.
-				time.Sleep(2 * time.Second)
+				select {
+				case <-time.After(2 * time.Second):
+				case <-ctx.Done():
+					return
+				}
 			}
 			if !filter.isActive(target) {
 				fmt.Fprintf(config.ErrOut, "failed to tail: %v\n", err)

--- a/stern/stern.go
+++ b/stern/stern.go
@@ -31,6 +31,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/time/rate"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/utils/ptr"
 
@@ -158,15 +159,19 @@ func Run(ctx context.Context, client kubernetes.Interface, config *Config) error
 			if err == nil {
 				return
 			}
+			if apierrors.IsNotFound(err) {
+				// When the pod is deleted, we'll receive an EOF.
+				// Since we retry EOF (see below), we may occasionally try to tail a deleted pod again.
+				// This case is detected here and we stop retrying without priting an error message.
+				return
+			}
 			if err == io.EOF {
-				// In most cases, EOF signals that the container has terminated.
-				// (and is no longer producting logs).
-				// However, long-running connections might also be closed gracefully by the API server
-				// (or a load balancer in between). Thus, we check whether the target is still active
-				// before stopping tailing logs.
-				if filter.isActive(target) {
-					continue
-				}
+				// In most situations, EOF means the container exited and we should stop tailing logs.
+				// However, the server may also close long-running connections with EOF.
+				// To ensure we retry fetching the pod logs in that case, we wait a bit before exiting.
+				// If we receive the "pod deleted" event during this time, then the
+				// target will be removed from the filter (see next check) and we won't retry.
+				time.Sleep(2 * time.Second)
 			}
 			if !filter.isActive(target) {
 				fmt.Fprintf(config.ErrOut, "failed to tail: %v\n", err)

--- a/stern/tail.go
+++ b/stern/tail.go
@@ -189,10 +189,7 @@ func (t *Tail) ConsumeRequest(ctx context.Context, request rest.ResponseWrapper)
 		}
 
 		if err != nil {
-			if err != io.EOF {
-				return err
-			}
-			return nil
+			return err
 		}
 	}
 }

--- a/stern/tail_test.go
+++ b/stern/tail_test.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/fatih/color"
 	"io"
 	"reflect"
 	"regexp"
 	"testing"
 	"text/template"
+
+	"github.com/fatih/color"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -119,7 +120,7 @@ line 4 (my-node/my-namespace/my-pod/my-container)
 			}
 			tail := NewTail(clientset.CoreV1(), pod, "my-container", tmpl, out, io.Discard, &TailOptions{}, false)
 			tail.resumeRequest = tt.resumeReq
-			if err := tail.ConsumeRequest(context.TODO(), &responseWrapperMock{data: bytes.NewBufferString(logLines)}); err != nil {
+			if err := tail.ConsumeRequest(context.TODO(), &responseWrapperMock{data: bytes.NewBufferString(logLines)}); err != io.EOF {
 				t.Fatalf("%d: unexpected err %v", i, err)
 			}
 
@@ -180,7 +181,7 @@ log 4 (my-namespace/my-pod/my-container)
 			}
 
 			tail := NewTail(clientset.CoreV1(), pod, "my-container", tmpl, out, io.Discard, &TailOptions{Highlight: []*regexp.Regexp{regexp.MustCompile("line")}}, false)
-			if err := tail.ConsumeRequest(context.TODO(), &responseWrapperMock{data: bytes.NewBufferString(tt.logLine)}); err != nil {
+			if err := tail.ConsumeRequest(context.TODO(), &responseWrapperMock{data: bytes.NewBufferString(tt.logLine)}); err != io.EOF {
 				t.Fatalf("%d: unexpected err %v", i, err)
 			}
 
@@ -248,7 +249,7 @@ func TestInclude(t *testing.T) {
 			}
 
 			tail := NewTail(clientset.CoreV1(), pod, "my-container", tmpl, out, io.Discard, &TailOptions{Include: []*regexp.Regexp{regexp.MustCompile("line")}}, false)
-			if err := tail.ConsumeRequest(context.TODO(), &responseWrapperMock{data: bytes.NewBufferString(tt.logLine)}); err != nil {
+			if err := tail.ConsumeRequest(context.TODO(), &responseWrapperMock{data: bytes.NewBufferString(tt.logLine)}); err != io.EOF {
 				t.Fatalf("%d: unexpected err %v", i, err)
 			}
 


### PR DESCRIPTION
## What this does

Fix #361

This change updates the logic to decide when the goroutine reading the logs for a pod should exit.

Before this change, receiving an EOF on the API request that fetches the logs would exit the goroutine. It was assumed that an EOF always means "the pod no longer exists". The goroutine is never recreated.

However, I suspect that, at least on GKE clusters, the client may receive an EOF (server gracefully closes the connection) in other situations (maybe a load balancer somewhere has a limit on the duration of an open connection). This would explain why stern eventually stops producing logs for long running pods (see linked issue).

When dumping the goroutine stack traces of a stern process that no longer produced logs, the goroutine that reads logs was missing. There was no error in stern output.

After this change, upon receiving an EOF, we also test whether we received a deletion event from the API (from the goroutine that watches pod creations and deletions). If not, we retry reading the logs.

This assumes that we never miss a pod deletion event, but avoids introducing an extra API request to check whether the pod still exists. I think that should work in practice. 

## How this was tested

I ran this modified version against a cluster that was exhibiting the issue described in #361, and I'm no longer able to reproduce it (whereas before I could reproduce 100% of the time).

## Caveat

I may have misunderstood the issue, or my fix may not be the correct solution. I'm less confident than what the above may seem to convey 🙂 