### PR TITLE
Add --qps and --burst flags to contorl client-side throttling

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Supported Kubernetes resources are `pod`, `replicationcontroller`, `service`, `d
  flag                        | default                       | purpose
 -----------------------------|-------------------------------|---------
  `--all-namespaces`, `-A`    | `false`                       | If present, tail across all namespaces. A specific namespace is ignored even if specified with --namespace.
+ `--burst`                   | `0`                           | Maximum burst for throttle to the Kubernetes API server. Defaults to 0 (use client-go default). Ignored when --qps=-1.
  `--color`                   | `auto`                        | Force set color output. 'auto':  colorize if tty attached, 'always': always colorize, 'never': never colorize.
  `--completion`              |                               | Output stern command-line completion code for the specified shell. Can be 'bash', 'zsh' or 'fish'.
  `--condition`               |                               | The condition to filter on: [condition-name[=condition-value]. The default condition-value is true. Match is case-insensitive. Currently only supported with --tail=0 or --no-follow.
@@ -105,6 +106,7 @@ Supported Kubernetes resources are `pod`, `replicationcontroller`, `service`, `d
  `--output`, `-o`            | `default`                     | Specify predefined template. Currently support: [default, raw, json, extjson, ppextjson]
  `--pod-colors`              |                               | Specifies the colors used to highlight pod names. Provide colors as a comma-separated list using SGR (Select Graphic Rendition) sequences, e.g., "91,92,93,94,95,96".
  `--prompt`, `-p`            | `false`                       | Toggle interactive prompt for selecting 'app.kubernetes.io/instance' label values.
+ `--qps`                     | `0`                           | Maximum QPS to the Kubernetes API server. Defaults to 0 (use client-go default). Use -1 to disable client-side throttling.
  `--selector`, `-l`          |                               | Selector (label query) to filter on. If present, default to ".*" for the pod-query.
  `--show-hidden-options`     | `false`                       | Print a list of hidden options.
  `--since`, `-s`             | `48h0m0s`                     | Return logs newer than a relative duration like 5s, 2m, or 3h.

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -83,6 +83,8 @@ type options struct {
 	verbosity           int
 	onlyLogLines        bool
 	maxLogRequests      int
+	qps                 float32
+	burst               int
 	node                string
 	configFilePath      string
 	showHiddenOptions   bool
@@ -143,6 +145,13 @@ func (o *options) Complete(args []string) error {
 	restConfig, err := o.configFlags.ToRESTConfig()
 	if err != nil {
 		return err
+	}
+
+	if o.qps != 0 {
+		restConfig.QPS = o.qps
+	}
+	if o.burst > 0 {
+		restConfig.Burst = o.burst
 	}
 
 	o.client = kubernetes.NewForConfigOrDie(restConfig)
@@ -448,6 +457,8 @@ func (o *options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringSliceVarP(&o.namespaces, "namespace", "n", o.namespaces, "Kubernetes namespace to use. Default to namespace configured in kubernetes context. To specify multiple namespaces, repeat this or set comma-separated value.")
 	fs.StringVar(&o.node, "node", o.node, "Node name to filter on.")
 	fs.IntVar(&o.maxLogRequests, "max-log-requests", o.maxLogRequests, "Maximum number of concurrent logs to request. Defaults to 50, but 5 when specifying --no-follow")
+	fs.Float32Var(&o.qps, "qps", o.qps, "Maximum QPS to the Kubernetes API server. Defaults to 0 (use client-go default). Use -1 to disable client-side throttling.")
+	fs.IntVar(&o.burst, "burst", o.burst, "Maximum burst for throttle to the Kubernetes API server. Defaults to 0 (use client-go default). Ignored when --qps=-1.")
 	fs.StringVarP(&o.output, "output", "o", o.output, "Specify predefined template. Currently support: [default, raw, json, extjson, ppextjson]")
 	fs.BoolVarP(&o.prompt, "prompt", "p", o.prompt, "Toggle interactive prompt for selecting 'app.kubernetes.io/instance' label values.")
 	fs.StringVarP(&o.selector, "selector", "l", o.selector, "Selector (label query) to filter on. If present, default to \".*\" for the pod-query.")

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 
@@ -152,6 +153,8 @@ func (o *options) Complete(args []string) error {
 	}
 	if o.burst > 0 {
 		restConfig.Burst = o.burst
+	} else if o.qps > 0 {
+		restConfig.Burst = rest.DefaultBurst
 	}
 
 	o.client = kubernetes.NewForConfigOrDie(restConfig)


### PR DESCRIPTION
Fixes #355 

These flags allows fine-grained control over client-side throttling. 

Defaults for `QPS` and `burst` are 5 and 10 respectively - https://github.com/kubernetes/client-go/blob/master/rest/config.go#L46-L49

--qps=<val>  -  set a custom limit. For e.g. --qps=100
--qps=-1 -  disable client-side throttling completely - https://github.com/kubernetes/client-go/blob/master/rest/config.go#L120
--burst=<value> - a custom burst limit. For e.g.  --burst=100

Verification:
**All tests succeed.** 

I'm a long time user of stern, but this is my contribution towards it. cc @superbrothers - please take a look :pray: 

@superbrothers I've been using stern for a long time in my work, but thiis is my first attempt to contribute to it .

Please take a look - thanks!