### PR TITLE
fix: close config file after reading

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -410,6 +410,7 @@ func (o *options) overrideFlagSetDefaultFromConfig(fs *pflag.FlagSet) error {
 	if err != nil {
 		return err
 	}
+	defer configFile.Close()
 
 	data := make(map[string]interface{})
 


### PR DESCRIPTION
 ## Summary
  - The config file opened in `readConfigFromFile` was never closed, leaking the file handle until process exit.
  - Added `defer configFile.Close()` immediately after the successful `os.Open`.

  ## Simple testing
  - [x] `go build ./...`
  - [x] `make build`
  
  