### PR TITLE
fix: change errorf format to represent real value

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -441,14 +441,14 @@ func (o *options) overrideFlagSetDefaultFromConfig(fs *pflag.FlagSet) error {
 					values[i] = fmt.Sprint(v)
 				}
 				if err := flagSlice.Replace(values); err != nil {
-					return fmt.Errorf("invalid value %q for %q in the config file: %v", value, name, err)
+					return fmt.Errorf("invalid value %v for %q in the config file: %v", value, name, err)
 				}
 				continue
 			}
 		}
 
 		if err := flag.Value.Set(fmt.Sprint(value)); err != nil {
-			return fmt.Errorf("invalid value %q for %q in the config file: %v", value, name, err)
+			return fmt.Errorf("invalid value %v for %q in the config file: %v", value, name, err)
 		}
 	}
 


### PR DESCRIPTION
[cmd/cmd.go:443]( https://github.com/Spuxy/stern/blob/be6c42e0566b98db0f7968d9f691ab7b24459f7c/cmd/cmd.go#L443)
 
 and 
 
[ cmd/cmd.go:450]( https://github.com/Spuxy/stern/blob/be6c42e0566b98db0f7968d9f691ab7b24459f7c/cmd/cmd.go#L450 )
 

both use `fmt.Errorf("invalid value %q for %q in the config file: %v", value, name, err)`. 
The first `%q` formats value, which is `interface{}` from a YAML decode (could be slice, int, bool, etc.), so `%q` is wrong. 
I have changed that first `%q` to `%v` on both lines.

```
[stern ± fix-config-error-format] ◯ go run . --config /tmp/stern-bug-demo/config.yaml foo
Error: invalid value 60 for "since" in the config file: time: missing unit in duration "60"
Usage:
  stern pod-query [flags]

Flags:
  -A, --all-namespaces                  If present, tail across all namespaces. A specific namespace is ignored even if specified with --namespace.
      --burst int                       Maximum burst for throttle to the Kubernetes API server. Defaults to 0 (use client-go default). Ignored when --qps=-1.
      --color string                    Force set color output. 'auto':  colorize if tty attached, 'always': always colorize, 'never': never colorize. (default "auto")
      --completion string               Output stern command-line completion code for the specified shell. Can be 'bash', 'zsh' or 'fish'.
      --condition string                The condition to filter on: [condition-name[=condition-value]. The default condition-value is true. Match is case-insensitive. Currently only supported with --tail=0 or --no-follow.
      --config string                   Path to the stern config file (default "~/.config/stern/config.yaml")
...
```

Testing yaml file:
```
[stern ± fix-config-error-format] ◯ cat /tmp/stern-bug-demo/config.yaml
     File: /tmp/stern-bug-demo/config.yaml
   1 since: 60
```