### PR TITLE
Keep .Message raw with --timestamps; expose timestamp as .Timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ will receive the following struct:
 | property        | type              | description                                 |
 |-----------------|-------------------|---------------------------------------------|
 | `Message`       | string            | The log message itself                      |
+| `Timestamp`     | string            | The log timestamp formatted per `--timestamps`/`--timezone`, empty unless `--timestamps` is set |
 | `NodeName`      | string            | The node name where the pod is scheduled on |
 | `Namespace`     | string            | The namespace of the pod                    |
 | `PodName`       | string            | The name of the pod                         |

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -541,12 +541,12 @@ func (o *options) generateTemplate() (*template.Template, error) {
 	if t == "" {
 		switch o.output {
 		case "default":
-			t = "{{color .PodColor .PodName}} {{color .ContainerColor .ContainerName}} {{.Message}}"
+			t = "{{color .PodColor .PodName}} {{color .ContainerColor .ContainerName}} {{if .Timestamp}}{{.Timestamp}} {{end}}{{.Message}}"
 			if o.allNamespaces || len(o.namespaces) > 1 {
 				t = fmt.Sprintf("{{color .PodColor .Namespace}} %s", t)
 			}
 		case "raw":
-			t = "{{.Message}}"
+			t = "{{if .Timestamp}}{{.Timestamp}} {{end}}{{.Message}}"
 		case "json":
 			t = "{{json .}}"
 		case "extjson":

--- a/stern/file_tail.go
+++ b/stern/file_tail.go
@@ -56,9 +56,10 @@ func (t *FileTail) ConsumeReader(reader *bufio.Reader) error {
 	}
 }
 
-func (t *FileTail) sprint(msg string) (string, error) {
+func (t *FileTail) sprint(msg string, timestamp string) (string, error) {
 	vm := Log{
 		Message:        msg,
+		Timestamp:      timestamp,
 		NodeName:       "",
 		Namespace:      "",
 		PodName:        "",
@@ -77,7 +78,7 @@ func (t *FileTail) sprint(msg string) (string, error) {
 
 // Print prints a color coded log message
 func (t *FileTail) Print(msg string) {
-	buf, err := t.sprint(msg)
+	buf, err := t.sprint(msg, "")
 	if err != nil {
 		fmt.Fprintf(t.errOut, "%s\n", err)
 		return
@@ -88,7 +89,7 @@ func (t *FileTail) Print(msg string) {
 
 // PrintWithoutHighlight prints a log message without applying any highlight.
 func (t *FileTail) PrintWithoutHighlight(msg string) {
-	buf, err := t.sprint(msg)
+	buf, err := t.sprint(msg, "")
 	if err != nil {
 		fmt.Fprintf(t.errOut, "%s\n", err)
 		return

--- a/stern/tail.go
+++ b/stern/tail.go
@@ -197,9 +197,10 @@ func (t *Tail) ConsumeRequest(ctx context.Context, request rest.ResponseWrapper)
 	}
 }
 
-func (t *Tail) sprint(msg string) (string, error) {
+func (t *Tail) sprint(msg string, timestamp string) (string, error) {
 	vm := Log{
 		Message:        msg,
+		Timestamp:      timestamp,
 		NodeName:       t.Pod.Spec.NodeName,
 		Namespace:      t.Pod.Namespace,
 		PodName:        t.Pod.Name,
@@ -219,8 +220,8 @@ func (t *Tail) sprint(msg string) (string, error) {
 }
 
 // Print prints a color coded log message with the pod and container names
-func (t *Tail) Print(msg string) {
-	buf, err := t.sprint(msg)
+func (t *Tail) Print(msg string, timestamp string) {
+	buf, err := t.sprint(msg, timestamp)
 	if err != nil {
 		fmt.Fprintf(t.errOut, "%s\n", err)
 		return
@@ -231,7 +232,7 @@ func (t *Tail) Print(msg string) {
 
 // PrintWithoutHighlight prints a log message without applying any highlight.
 func (t *Tail) PrintWithoutHighlight(msg string) {
-	buf, err := t.sprint(msg)
+	buf, err := t.sprint(msg, "")
 	if err != nil {
 		fmt.Fprintf(t.errOut, "%s\n", err)
 		return
@@ -266,16 +267,17 @@ func (t *Tail) consumeLine(line string) {
 		return
 	}
 
+	var timestamp string
 	if t.Options.Timestamps {
 		updatedTs, err := t.Options.UpdateTimezoneAndFormat(rfc3339Nano)
 		if err != nil {
 			t.PrintWithoutHighlight(fmt.Sprintf("[%v] %s", err, line))
 			return
 		}
-		content = updatedTs + " " + content
+		timestamp = updatedTs
 	}
 
-	t.Print(content)
+	t.Print(content, timestamp)
 }
 
 func (t *Tail) rememberLastTimestamp(timestamp string) {

--- a/stern/tail_test.go
+++ b/stern/tail_test.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"testing"
 	"text/template"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -444,5 +445,55 @@ func TestRemoveSubsecond(t *testing.T) {
 		if tt.expected != actual {
 			t.Errorf("expected %v, but actual %v", tt.expected, actual)
 		}
+	}
+}
+
+// Regression test for stern/stern#342: when --timestamps is enabled, the
+// timestamp must be exposed via the separate .Timestamp template field and must
+// NOT be prepended to .Message, otherwise templates that parse .Message as JSON
+// fail with "invalid character ... after top-level value".
+func TestConsumeStreamTailTimestamp(t *testing.T) {
+	logLines := `2023-02-13T21:20:30.000000001Z {"msg":"hello"}
+2023-02-13T21:20:31.000000002Z {"msg":"world"}`
+
+	tests := []struct {
+		name     string
+		tmpl     *template.Template
+		expected []byte
+	}{
+		{
+			// .Message stays raw and parseable as JSON.
+			name:     "message stays raw json",
+			tmpl:     template.Must(template.New("").Parse(`{{.Message}}` + "\n")),
+			expected: []byte("{\"msg\":\"hello\"}\n{\"msg\":\"world\"}\n"),
+		},
+		{
+			// .Timestamp carries the formatted timestamp separately.
+			name:     "timestamp available as field",
+			tmpl:     template.Must(template.New("").Parse(`{{.Timestamp}} {{.Message}}` + "\n")),
+			expected: []byte("02-13 21:20:30 {\"msg\":\"hello\"}\n02-13 21:20:31 {\"msg\":\"world\"}\n"),
+		},
+	}
+
+	clientset := fake.NewSimpleClientset()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := new(bytes.Buffer)
+			errOut := new(bytes.Buffer)
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "my-namespace", Name: "my-pod"},
+			}
+			tail := NewTail(clientset.CoreV1(), pod, "my-container", tt.tmpl, out, errOut,
+				&TailOptions{Timestamps: true, TimestampFormat: TimestampFormatShort, Location: time.UTC}, false)
+			if err := tail.ConsumeRequest(context.TODO(), &responseWrapperMock{data: bytes.NewBufferString(logLines)}); err != nil {
+				t.Fatalf("unexpected err %v", err)
+			}
+			if errOut.Len() != 0 {
+				t.Fatalf("unexpected template error: %s", errOut.String())
+			}
+			if !bytes.Equal(tt.expected, out.Bytes()) {
+				t.Errorf("expected `%s`, but actual `%s`", tt.expected, out)
+			}
+		})
 	}
 }

--- a/stern/tail_utils.go
+++ b/stern/tail_utils.go
@@ -17,6 +17,11 @@ type Log struct {
 	// Message is the log message itself
 	Message string `json:"message"`
 
+	// Timestamp is the log timestamp, formatted according to --timestamps and
+	// --timezone. It is empty when --timestamps is not set. It is kept separate
+	// from Message so that templates can still parse Message as JSON.
+	Timestamp string `json:"timestamp,omitempty"`
+
 	// Node name of the pod
 	NodeName string `json:"nodeName"`
 


### PR DESCRIPTION
Fixes #342.

### Problem

With `--timestamps`, stern prepends the timestamp onto the log content that becomes `.Message`. So template helpers that parse `.Message` as JSON — `extractJSONParts`, `parseJSON`, `tryParseJSON`, `prettyJSON`, `extjson` — receive `2023-... {"...":...}` instead of `{"...":...}` and fail with `invalid character '<digit>' after top-level value` (exactly the error in #342). The README documents `.Message` as "the log message itself", so this is a contract violation, and there was no separate field to get the timestamp from.

### Fix

Keep `.Message` raw and expose the timestamp as a new `.Timestamp` template field:
- add `Timestamp` to the `Log` struct; `consumeLine` no longer mutates the content, it passes the timestamp through to `sprint`.
- the built-in `default` and `raw` templates render `{{if .Timestamp}}{{.Timestamp}} {{end}}{{.Message}}` — visible output is unchanged when `--timestamps` is on, and byte-identical when off (empty field).
- documented `.Timestamp` in the README.

### Testing

Added `TestConsumeStreamTailTimestamp`: with `--timestamps`, `{{.Message}}` stays raw JSON and `{{.Timestamp}}` carries the timestamp. Fails before the fix (`.Message` polluted; `.Timestamp` undefined), passes after. `go test ./...` green.
