### PR TITLE
Support nested field extraction via dot notation in extractJSONParts

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,8 @@ functions](https://golang.org/pkg/text/template/#hdr-Functions)):
 | `color`               | `color.Color, string`       | Wrap the text in color (.ContainerColor and .PodColor provided)                                                                             |
 | `parseJSON`           | `string`                    | Parse string as JSON                                                                                                                        |
 | `tryParseJSON`        | `string`                    | Attempt to parse string as JSON, return nil on failure                                                                                      |
-| `extractJSONParts`    | `string, ...string`         | Parse string as JSON and concatenate the given keys.                                                                                        |
-| `tryExtractJSONParts` | `string, ...string`         | Attempt to parse string as JSON and concatenate the given keys. , return text on failure                                                    |
+| `extractJSONParts`    | `string, ...string`         | Parse string as JSON and concatenate the given keys. Keys may use dot notation (e.g. `python.levelname`) to access nested fields.           |
+| `tryExtractJSONParts` | `string, ...string`         | Attempt to parse string as JSON and concatenate the given keys (dot notation accesses nested fields), return text on failure.               |
 | `prettyJSON`          | `any`                       | Parse input and emit it as pretty printed JSON, if parse fails output string as is.                                                         |
 | `toRFC3339Nano`       | `object`                    | Parse timestamp (string, int, json.Number) and output it using RFC3339Nano format                                                           |
 | `toTimestamp`         | `object, string [, string]` | Parse timestamp (string, int, json.Number) and output it using the given layout in the timezone that is optionally given (defaults to UTC). |
@@ -348,6 +348,13 @@ Pretty print JSON (if it is JSON) and output it:
 stern --template='{{ .Message | prettyJSON }}{{"\n"}}' backend
 # Or with parsed json, will drop non-json logs because of `with`
 stern --template='{{ with $msg := .Message | tryParseJSON }}{{ prettyJSON $msg }}{{"\n"}}{{end}}' backend
+```
+
+Extract fields from JSON, including nested fields via dot notation:
+
+```
+# Given a message like {"python": {"levelname": "INFO", "module": "router"}}
+stern --template='{{ levelColor (extractJSONParts .Message "python.levelname") }} {{ extractJSONParts .Message "python.module" }}{{"\n"}}' backend
 ```
 
 Load custom template from file:

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -598,7 +598,7 @@ func (o *options) generateTemplate() (*template.Template, error) {
 			}
 			parts := make([]string, 0)
 			for _, key := range part {
-				parts = append(parts, fmt.Sprintf("%v", obj[key]))
+				parts = append(parts, fmt.Sprintf("%v", extractJSONPart(obj, key)))
 			}
 			return strings.Join(parts, ", "), nil
 		},
@@ -609,7 +609,7 @@ func (o *options) generateTemplate() (*template.Template, error) {
 			}
 			parts := make([]string, 0)
 			for _, key := range part {
-				parts = append(parts, fmt.Sprintf("%v", obj[key]))
+				parts = append(parts, fmt.Sprintf("%v", extractJSONPart(obj, key)))
 			}
 			return strings.Join(parts, ", ")
 		},
@@ -754,6 +754,29 @@ func (o *options) generateTemplate() (*template.Template, error) {
 		return nil, errors.Wrap(err, "unable to parse template")
 	}
 	return template, err
+}
+
+// extractJSONPart resolves a key against a decoded JSON object. The key is first
+// looked up as a literal top-level key to preserve backward compatibility; if it
+// is absent, the key is treated as a dot-separated path and walked through nested
+// objects (e.g. "python.levelname" descends into the "python" object and reads
+// "levelname"). A missing key or a non-object value along the path yields nil.
+func extractJSONPart(obj map[string]interface{}, key string) interface{} {
+	if v, ok := obj[key]; ok {
+		return v
+	}
+
+	var current interface{} = obj
+	for _, segment := range strings.Split(key, ".") {
+		m, ok := current.(map[string]interface{})
+		if !ok {
+			return nil
+		}
+		if current, ok = m[segment]; !ok {
+			return nil
+		}
+	}
+	return current
 }
 
 func (o *options) generateFieldSelector() (fields.Selector, error) {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -498,6 +498,72 @@ func TestOptionsGenerateTemplate(t *testing.T) {
 			"pod1 [<no value>] message with missing annotation",
 			false,
 		},
+		{
+			"template with extractJSONParts flat key",
+			func() *options {
+				o := NewOptions(streams)
+				o.template = `{{extractJSONParts .Message "level"}}`
+				return o
+			}(),
+			`{"level":"INFO"}`,
+			"INFO",
+			false,
+		},
+		{
+			"template with extractJSONParts nested key",
+			func() *options {
+				o := NewOptions(streams)
+				o.template = `{{extractJSONParts .Message "python.levelname"}}`
+				return o
+			}(),
+			`{"python":{"levelname":"INFO","lineno":96}}`,
+			"INFO",
+			false,
+		},
+		{
+			"template with extractJSONParts multiple nested keys",
+			func() *options {
+				o := NewOptions(streams)
+				o.template = `{{extractJSONParts .Message "python.levelname" "python.lineno"}}`
+				return o
+			}(),
+			`{"python":{"levelname":"INFO","lineno":96}}`,
+			"INFO, 96",
+			false,
+		},
+		{
+			"template with extractJSONParts missing nested key",
+			func() *options {
+				o := NewOptions(streams)
+				o.template = `{{extractJSONParts .Message "python.missing"}}`
+				return o
+			}(),
+			`{"python":{"levelname":"INFO"}}`,
+			"<nil>",
+			false,
+		},
+		{
+			"template with tryExtractJSONParts nested key",
+			func() *options {
+				o := NewOptions(streams)
+				o.template = `{{tryExtractJSONParts .Message "python.levelname"}}`
+				return o
+			}(),
+			`{"python":{"levelname":"INFO"}}`,
+			"INFO",
+			false,
+		},
+		{
+			"template with tryExtractJSONParts on invalid json",
+			func() *options {
+				o := NewOptions(streams)
+				o.template = `{{tryExtractJSONParts .Message "python.levelname"}}`
+				return o
+			}(),
+			"not json",
+			"not json",
+			false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -533,6 +599,39 @@ func TestOptionsGenerateTemplate(t *testing.T) {
 			}
 			if want, got := tt.want, buf.String(); want != got {
 				t.Errorf("want %v, but got %v", want, got)
+			}
+		})
+	}
+}
+
+func TestExtractJSONPart(t *testing.T) {
+	obj := map[string]interface{}{
+		"level": "INFO",
+		"python": map[string]interface{}{
+			"levelname": "INFO",
+			"lineno":    float64(96),
+		},
+		"with.dot": "literal",
+	}
+
+	tests := []struct {
+		name string
+		key  string
+		want interface{}
+	}{
+		{"flat key", "level", "INFO"},
+		{"nested key", "python.levelname", "INFO"},
+		{"nested numeric key", "python.lineno", float64(96)},
+		{"literal key containing a dot", "with.dot", "literal"},
+		{"missing top-level key", "missing", nil},
+		{"missing nested key", "python.missing", nil},
+		{"path through a non-object value", "level.deeper", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractJSONPart(obj, tt.key); got != tt.want {
+				t.Errorf("extractJSONPart(obj, %q) = %v, want %v", tt.key, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
The extractJSONParts / tryExtractJSONParts template functions only did a flat
top-level key lookup, so a dotted key like `python.levelname` never matched a
nested field and rendered as `<nil>` (issue #343).

This makes both functions resolve a key as a dot-separated path, walking nested
JSON objects. A literal top-level key is still tried first, so existing flat-key
usage (including keys that already contain a dot) is unchanged.

Validation (run locally):
- make lint: 0 issues (golangci-lint v2.12.1)
- go test ./...: ok (added table tests for the helper plus template-level cases:
  flat key, nested key, multiple keys, missing nested key, invalid-JSON passthrough)
- go vet ./... and gofmt -l: clean

related: #343

---
Generated with assistance from Claude Code (Opus 4.8), reviewed and validated locally by the author.